### PR TITLE
Fix: Address security issues flagged by GitHub tooling, e.g. CodeQL

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -403,7 +403,15 @@ jobs:
             pdm-makefile-${{ runner.os }}-
 
       - name: Install PDM
-        run: pip install pdm==2.24.2
+        run: |
+          # Generate PDM requirements with complete dependency tree and hashes
+          python3 scripts/generate_requirements.py \
+            --platform linux_x86_64 \
+            --python-version 311 \
+            --output /tmp/pdm-requirements.txt \
+            --comment "PDM with complete dependency tree" \
+            pdm==2.24.2
+          pip install --require-hashes -r /tmp/pdm-requirements.txt
 
       - name: Test Makefile targets
         run: |
@@ -460,7 +468,14 @@ jobs:
 
       - name: Install PDM and dependencies
         run: |
-          pip install pdm==2.24.2
+          # Generate PDM requirements with complete dependency tree and hashes
+          python3 scripts/generate_requirements.py \
+            --platform linux_x86_64 \
+            --python-version 311 \
+            --output /tmp/pdm-requirements.txt \
+            --comment "PDM with complete dependency tree" \
+            pdm==2.24.2
+          pip install --require-hashes -r /tmp/pdm-requirements.txt
           pdm install -G test
 
       - name: Test CLI help and version
@@ -738,3 +753,126 @@ jobs:
         if: always()
         run: |
           docker rm -f go-httpbin || true
+
+  # Security scan job
+  security-scan:
+    name: 'Security Scan'
+    runs-on: ubuntu-latest
+    needs: [python-build]
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      # Harden the runner
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Setup Python with caching
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-docker.txt
+            pyproject.toml
+
+      # Cache PDM dependencies
+      - name: Cache PDM dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ./.venv
+            ~/.cache/pip
+            ~/.cache/pdm
+          key: ${{ runner.os }}-security-scan-deps-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-security-scan-deps-
+            ${{ runner.os }}-security-scan-
+
+      # Install security tools
+      - name: Install security scanning tools
+        run: |
+          # Ensure we have a recent version of pip that supports --hash properly
+          VERSION=$(pip --version)
+          echo "Using pip version: $VERSION"
+
+          # Generate requirements file with complete dependency tree and hashes
+          echo "Generating security tools requirements with all transitive dependencies..."
+          python3 scripts/generate_requirements.py \
+            --platform linux_x86_64 \
+            --python-version 310 \
+            --output /tmp/security-requirements.txt \
+            --comment "Security scanning tools with complete dependency tree" \
+            safety==3.6.0 \
+            bandit==1.8.3 \
+            pip-audit==2.7.3
+
+          # Install security tools with hash verification using requirements file
+          echo "Installing security tools with hash verification..."
+          pip install --require-hashes -r /tmp/security-requirements.txt
+
+      # Check pip install security (SHA pinning)
+      - name: Check pip install commands for SHA hash pinning
+        run: |
+          echo "::group::Pip Install Security Check"
+          python3 scripts/check-pip-security.py
+          echo "::endgroup::"
+
+      # Run safety check
+      - name: Run safety check
+        run: |
+          echo "::group::Safety Dependency Check"
+          safety check --full-report
+          echo "::endgroup::"
+        continue-on-error: true
+
+      # Run bandit
+      - name: Run bandit static code analysis
+        run: |
+          echo "::group::Bandit Static Analysis"
+          bandit -r src/ -c pyproject.toml -ll
+          echo "::endgroup::"
+
+      # Run pip-audit
+      - name: Run pip-audit for vulnerabilities
+        run: |
+          echo "::group::Pip Audit"
+          pip-audit -r requirements-docker.txt || true
+          pip-audit -f json -r requirements-docker.txt > security-report.json || true
+          echo "::endgroup::"
+        continue-on-error: true
+
+      # Check for specific vulnerabilities
+      - name: Check for known vulnerabilities
+        run: |
+          echo "::group::Targeted Vulnerability Check"
+
+          # Check for MongoDB driver vulnerability (GHSA-48p4-8xcf-vxj5)
+          echo "Checking for MongoDB driver vulnerability (GHSA-48p4-8xcf-vxj5)..."
+          if pip list | grep -i mongodb; then
+            echo "::warning::MongoDB driver detected - check version for GHSA-48p4-8xcf-vxj5 vulnerability"
+          else
+            echo "MongoDB driver not found - not vulnerable to GHSA-48p4-8xcf-vxj5"
+          fi
+
+          # Check for Request package vulnerability (GHSA-pq67-6m6q-mj2v)
+          echo "Checking for Request package vulnerability (GHSA-pq67-6m6q-mj2v)..."
+          if pip list | grep -i requests; then
+            # The vulnerability affects all versions of the deprecated 'request' package
+            # Warn if it's being used directly in production code
+            if grep -r "import requests" src/ --include="*.py" || grep -r "from requests" src/ --include="*.py"; then
+              echo "::warning::Requests package is directly imported in code - check usage patterns for SSRF vulnerabilities"
+            else
+              echo "Requests package is a dependency but not directly imported - lower risk"
+            fi
+          else
+            echo "Requests package not found - not vulnerable to GHSA-pq67-6m6q-mj2v"
+          fi
+
+          echo "::endgroup::"

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -86,7 +86,14 @@ jobs:
         if: steps.tox-ini.outputs.type == 'file'
         run: |
           # Build documentation (tox/sphinx)
-          pip --disable-pip-version-check install --upgrade tox
+          # Generate tox requirements with complete dependency tree and hashes
+          python3 scripts/generate_requirements.py \
+            --platform linux_x86_64 \
+            --python-version 311 \
+            --output /tmp/tox-requirements.txt \
+            --comment "Tox with complete dependency tree" \
+            tox==4.27.0
+          pip --disable-pip-version-check install --require-hashes -r /tmp/tox-requirements.txt
           tox -e docs
           echo "Tox documentation build ✅"
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # PDM
 .pdm-python
 
+# Generated requirements files (created dynamically)
+requirements-docker.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,16 @@ repos:
       - id: codespell
         args: ["--ignore-words=.codespell"]
 
+  # Security check for pip install commands in workflows
+  - repo: local
+    hooks:
+      - id: check-pip-security
+        name: Check pip install security (SHA pinning)
+        entry: python3 scripts/check-pip-security.py
+        language: system
+        files: ^\.github/workflows/.*\.(yml|yaml)$
+        description: "Ensure all pip install commands use SHA256 hash pinning for security"
+
   - repo: https://github.com/python-jsonschema/check-jsonschema.git
     rev: 54da05914997e6b04e4db33ed6757d744984c68b  # frozen: 0.33.2
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ test-cov: install-test ## Run tests with coverage
 lint: ## Run linting checks
 	pdm run pre-commit run --all-files
 
+security-check: ## Check pip install commands for SHA hash pinning
+	python3 scripts/check-pip-security.py
+
 format: ## Format code
 	pdm run pre-commit run --all-files ruff-format
 
@@ -124,7 +127,7 @@ pre-commit-install: ## Install pre-commit hooks
 pre-commit-run: ## Run pre-commit hooks on all files
 	pdm run pre-commit run --all-files
 
-ci: install-dev lint test ## Run CI pipeline locally
+ci: install-dev lint security-check test ## Run CI pipeline locally
 
 setup-dev: install-dev pre-commit-install ## Setup development environment
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,49 @@ pdm run pre-commit install
 pdm run pre-commit run --all-files
 ```
 
+### Docker Requirements Management
+
+The Docker image uses a **dynamic requirements generation** approach where the
+Docker build process generates the `requirements-docker.txt` file to
+ensure correct platform compatibility.
+
+If you need to manually regenerate for local development:
+
+```bash
+# Regenerate requirements-docker.txt with all dependencies and hashes
+python3 scripts/generate_requirements.py \
+  --platform linux_x86_64 \
+  --python-version 311 \
+  --output requirements-docker.txt \
+  --comment "PDM and all its dependencies for Linux x86_64 platform" \
+  pdm==2.24.2
+
+# Or specify a different PDM version
+python3 scripts/generate_requirements.py \
+  --platform linux_x86_64 \
+  --python-version 311 \
+  --output requirements-docker.txt \
+  --comment "PDM and all its dependencies for Linux x86_64 platform" \
+  pdm==2.26.0
+
+# Test the Docker build
+docker build . --platform linux/arm64 -t http-api-tool-test
+```
+
+The `requirements-docker.txt` file contains:
+
+- PDM and all its transitive dependencies
+- SHA256 hashes for Linux ARM64 platform
+- Security protection against supply chain attacks
+- Ensures reproducible Docker builds
+
+**When to regenerate:**
+
+- Updating PDM version in the project
+- Docker build failures with hash verification errors
+- Setting up the project for the first time
+- After changes to `pyproject.toml` affecting PDM dependencies
+
 ### Local Development
 
 ```bash

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2025 The Linux Foundation
-
-# PDM pinned for security compliance and reproducible builds
-# Version pinning provides security through deterministic builds
-pdm==2.25.4

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,178 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 The Linux Foundation
+-->
+
+# Security Scripts
+
+This directory contains security-related scripts and tools for the project.
+
+## check-pip-security.py
+
+A security linter that enforces SHA256 hash pinning for all pip install
+commands in GitHub workflows.
+
+### Purpose
+
+This script prevents supply chain attacks by ensuring that all pip install
+commands with version constraints also include SHA256 hash verification.
+This provides protection against:
+
+- Package substitution attacks
+- Repository compromise
+- Dependency confusion attacks
+- Ensures deterministic builds
+
+### Usage
+
+```bash
+# Check all workflow files
+python3 scripts/check-pip-security.py
+
+# Check specific files
+python3 scripts/check-pip-security.py .github/workflows/build-test.yaml
+
+# Via make target
+make security-check
+```
+
+### Integration
+
+The project's security infrastructure integrates this script:
+
+1. **Pre-commit Hook**: Automatically runs on workflow file changes
+2. **GitHub Actions**: Runs as part of the security-scan job in CI
+3. **Make Target**: Available via `make security-check` for local development
+
+### Example Violations and Fixes
+
+**Violation:**
+
+```yaml
+- name: Install package
+  run: pip install requests==2.31.0
+```
+
+**Fixed:**
+
+```yaml
+- name: Install package
+  run: pip install requests==2.31.0 \
+    --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
+```
+
+### Safe Patterns (Not Flagged)
+
+These patterns are safe and won't trigger violations:
+
+- `pip install --upgrade pip` (pip upgrading itself)
+- `pip install -r requirements.txt` (requirements files - checked separately)
+- `pip install -e .` (editable installs for development)
+- `pip install .` (current directory installation)
+
+### Getting SHA Hashes
+
+To get SHA256 hashes for packages:
+
+```bash
+# Download and get hash
+pip download --no-deps package==version
+sha256sum package-version-py3-none-any.whl
+```
+
+### Configuration
+
+Configure the script via:
+
+- `.pre-commit-config.yaml` - Pre-commit hook configuration
+- `Makefile` - Make target definition
+- `.github/workflows/build-test.yaml` - CI integration
+
+## generate_requirements.py
+
+A universal utility script that generates complete requirements files with all
+dependencies and their SHA256 hashes for any specified packages and platform.
+This ensures reproducible builds and protects against supply chain attacks.
+
+### Requirements Generation Purpose
+
+This script solves the hash verification challenge by:
+
+- Capturing all transitive dependencies for any package installation
+- Downloading packages for any specified platform and Python version
+- Generating SHA256 hashes for all dependencies
+- Creating requirements files compatible with pip's `--require-hashes` mode
+
+### Requirements Generation Usage
+
+```bash
+# Generate requirements for security tools (e.g., for CI workflows)
+python3 scripts/generate_requirements.py \
+  --platform linux_x86_64 \
+  --python-version 310 \
+  --output /tmp/security-requirements.txt \
+  --comment "Security scanning tools" \
+  safety==3.6.0 bandit==1.8.3 pip-audit==2.7.3
+
+# Generate requirements-docker.txt for PDM (Docker builds)
+python3 scripts/generate_requirements.py \
+  --platform linux_aarch64 \
+  --python-version 311 \
+  --output requirements-docker.txt \
+  --comment "PDM and all its dependencies for Linux ARM64 platform" \
+  pdm==2.24.2
+
+# Generate for different PDM version
+python3 scripts/generate_requirements.py \
+  --platform linux_aarch64 \
+  --python-version 311 \
+  --output requirements-docker.txt \
+  --comment "PDM and all its dependencies for Linux ARM64 platform" \
+  pdm==2.26.0
+```
+
+### When to Use
+
+Run this script when:
+
+- Setting up CI workflows that need hash-verified package installations
+- Creating Docker images that require reproducible builds
+- **Docker builds automatically use this script during the build process**
+- Updating package versions in any environment
+- Ensuring supply chain security compliance
+
+- Updating PDM version in the Docker container
+- Docker build fails with hash verification errors
+- Setting up the project for the first time
+- Dependencies change in `pyproject.toml`
+
+### Output
+
+The script generates `requirements-docker.txt` containing:
+
+```text
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# PDM and all its dependencies with SHA256 hash verification
+# This ensures reproducible builds and protection against supply chain attacks
+# Generated for Linux ARM64 platform
+
+pdm==2.25.4 \
+    --hash=sha256:3efab7367cb5d9d6e4ef9db6130e4f5620c247343c8e95e18bd0d76b201ff7da
+# ... all other dependencies with hashes
+```
+
+### Integration with Docker
+
+The Dockerfile uses the generated file:
+
+```dockerfile
+# Copy requirements file with hashes
+COPY requirements-docker.txt ./
+
+# Install PDM with hash verification
+RUN pip install -r requirements-docker.txt
+```
+
+This ensures that pip's `--require-hashes` mode works and verifies all dependencies.

--- a/scripts/check-pip-security.py
+++ b/scripts/check-pip-security.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Security linter for pip install commands in GitHub workflows.
+
+This script enforces that all pip install commands in GitHub workflows
+use SHA256 hash pinning for security compliance.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    """Main function to check pip install security."""
+    parser = argparse.ArgumentParser(
+        description="Check GitHub workflows for pip install commands without SHA hashes"
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to check (if empty, checks all workflow files)"
+    )
+
+    args = parser.parse_args()
+
+    # Determine files to check
+    if args.files:
+        files_to_check = [Path(f) for f in args.files]
+    else:
+        # Default to checking all workflow files
+        workflow_dir = Path('.github/workflows')
+        if workflow_dir.exists():
+            files_to_check = list(workflow_dir.glob('*.yml')) + list(workflow_dir.glob('*.yaml'))
+        else:
+            print("No .github/workflows directory found", file=sys.stderr)
+            return 1
+
+    violation_count = 0
+
+    for file_path in files_to_check:
+        if not file_path.exists() or file_path.suffix not in ['.yml', '.yaml']:
+            continue
+
+        violations = check_file_for_violations(file_path)
+        violation_count += violations
+
+    if violation_count > 0:
+        print_security_guidance()
+        return 1
+
+    print("✅ All pip install commands use proper SHA hash pinning")
+    return 0
+
+
+def check_file_for_violations(file_path: Path) -> int:
+    """Check a single file for pip install violations."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"Warning: Could not read {file_path}: {e}", file=sys.stderr)
+        return 0
+
+    violations = 0
+    lines = content.splitlines()
+
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+
+        # Check for pip install commands
+        if re.search(r'\bpip\s+.*install\b', line):
+            # Collect full command (may span multiple lines)
+            command_lines = [line]
+            while line.endswith('\\') and i + 1 < len(lines):
+                i += 1
+                line = lines[i].strip()
+                command_lines.append(line)
+
+            full_command = ' '.join(command_lines)
+
+            if is_violation(full_command):
+                violations += 1
+                print(f"❌ Violation in {file_path}:{i + 1}")
+                print(f"   Command: {full_command}")
+                print()
+
+        i += 1
+
+    return violations
+
+
+def is_violation(command: str) -> bool:
+    """Check if a pip install command violates security requirements."""
+    # Skip safe patterns
+    safe_patterns = [
+        r'pip\s+.*install\s+--upgrade\s+pip\s*$',  # pip upgrade itself
+        r'pip\s+.*install\s+-r\s+',  # requirements file
+        r'pip\s+.*install\s+-e\s+',  # editable installs
+        r'pip\s+.*install\s+\.\s*$',  # current directory
+    ]
+
+    for pattern in safe_patterns:
+        if re.search(pattern, command, re.IGNORECASE):
+            return False
+
+    # Check for package with version constraints
+    has_version = re.search(r'\b[a-zA-Z0-9_-]+\s*[><=!~]+\s*[0-9.]+', command)
+    has_hash = '--hash=' in command or '--hash ' in command
+
+    return bool(has_version and not has_hash)
+
+
+def print_security_guidance() -> None:
+    """Print security guidance for fixing violations."""
+    print()
+    print("🔒 Security Requirement:")
+    print("All pip install commands with version constraints must use SHA256 hash pinning")
+    print("to prevent supply chain attacks and ensure deterministic builds.")
+    print()
+    print("Recommended approach:")
+    print("  Use the provided script to generate requirements with complete dependency tree:")
+    print("  python3 scripts/generate_requirements.py \\")
+    print("    --platform linux_x86_64 \\")
+    print("    --python-version 311 \\")
+    print("    --output /tmp/requirements.txt \\")
+    print("    package==1.0.0")
+    print("  pip install --require-hashes -r /tmp/requirements.txt")
+    print()
+    print("Manual approach (not recommended for complex dependencies):")
+    print("  cat > requirements.txt << 'EOF'")
+    print("  package==1.0.0 \\")
+    print("    --hash=sha256:abcd1234...")
+    print("  EOF")
+    print("  pip install --require-hashes -r requirements.txt")
+    print()
+    print("Note: --hash is a per-requirement option for requirements files only,")
+    print("      not a command-line option for 'pip install'. When using --require-hashes,")
+    print("      ALL dependencies (including transitive ones) must have hashes.")
+    print()
+    print("For more information, see:")
+    print("https://pip.pypa.io/en/stable/topics/secure-installs/")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_requirements.py
+++ b/scripts/generate_requirements.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Generate requirements file with complete dependency tree and correct hashes.
+
+This script generates a complete requirements file with:
+- All transitive dependencies for given packages
+- SHA256 hashes for specified platform
+- Protection against supply chain attacks
+- Reproducible builds
+
+Usage:
+    python3 scripts/generate_requirements_with_hashes.py [OPTIONS] PACKAGE1 PACKAGE2 ...
+
+Examples:
+    python3 scripts/generate_requirements_with_hashes.py safety==3.6.0 bandit==1.8.3
+    python3 scripts/generate_requirements_with_hashes.py --platform linux_x86_64 --python-version 310 safety==3.6.0
+    python3 scripts/generate_requirements_with_hashes.py --output /tmp/security-requirements.txt safety==3.6.0 bandit==1.8.3 pip-audit==2.7.3
+"""
+
+import argparse
+import hashlib
+import subprocess
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+def get_all_dependencies(packages: List[str]) -> List[str]:
+    """Get all dependencies including transitive ones using pip install --dry-run --report."""
+    deps_report = '/tmp/deps-report.json'
+
+    print(f"Getting complete dependency tree for: {', '.join(packages)}")
+
+    # Get complete dependency tree
+    result = subprocess.run([
+        'pip', 'install', '--dry-run', '--report', deps_report
+    ] + packages, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        print(f"Error getting dependencies: {result.stderr}", file=sys.stderr)
+        return []
+
+    # Parse JSON report to get all packages
+    with open(deps_report) as f:
+        report = json.load(f)
+
+    dependencies = []
+    for item in report['install']:
+        name = item['metadata']['name']
+        version = item['metadata']['version']
+        dependencies.append(f"{name}=={version}")
+
+    # Clean up
+    Path(deps_report).unlink(missing_ok=True)
+
+    return sorted(set(dependencies))
+
+def download_and_hash(packages: List[str], platform: str, python_version: str) -> Dict[str, str]:
+    """Download packages and get their SHA256 hashes."""
+    wheels_dir = Path('/tmp/wheels-download')
+    if wheels_dir.exists():
+        subprocess.run(['rm', '-rf', str(wheels_dir)])
+    wheels_dir.mkdir()
+
+    print(f"Downloading packages for platform {platform}, Python {python_version}...")
+
+    # First try with platform specification and binary-only
+    cmd = [
+        'pip', 'download',
+        '--platform', platform,
+        '--python-version', python_version,
+        '--only-binary=:all:',
+        '--no-deps',
+        '-d', str(wheels_dir)
+    ] + packages
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    # If that fails, try without platform constraints (will get current platform)
+    if result.returncode != 0:
+        print("Platform-specific download failed, trying without platform constraints...")
+        print(f"Error was: {result.stderr}")
+
+        # Clean up and try again without platform constraints
+        subprocess.run(['rm', '-rf', str(wheels_dir)])
+        wheels_dir.mkdir()
+
+        cmd = [
+            'pip', 'download',
+            '--only-binary=:all:',
+            '--no-deps',
+            '-d', str(wheels_dir)
+        ] + packages
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            print(f"Error downloading packages: {result.stderr}", file=sys.stderr)
+            return {}
+
+    # Generate hashes
+    hashes = {}
+    for wheel_file in wheels_dir.glob('*.whl'):
+        # Extract package name and version from filename
+        parts = wheel_file.name.split('-')
+        package_name = parts[0].replace('_', '-').lower()
+        version = parts[1]
+
+        # Get SHA256 hash using hashlib for portability
+        with open(wheel_file, 'rb') as f:
+            file_contents = f.read()
+            hash_value = hashlib.sha256(file_contents).hexdigest()
+        hashes[f"{package_name}=={version}"] = hash_value
+
+    # Clean up
+    subprocess.run(['rm', '-rf', str(wheels_dir)])
+
+    return hashes
+
+def generate_requirements_content(packages_with_hashes: Dict[str, str], comment: str | None = None) -> str:
+    """Generate the requirements file content."""
+    content = [
+        "# SPDX-License-Identifier: Apache-2.0",
+        "# SPDX-FileCopyrightText: 2025 The Linux Foundation",
+        "",
+    ]
+
+    if comment:
+        content.extend([
+            f"# {comment}",
+            ""
+        ])
+
+    content.extend([
+        "# Complete dependency tree with SHA256 hash verification",
+        "# This ensures reproducible builds and protection against supply chain attacks",
+        ""
+    ])
+
+    for package in sorted(packages_with_hashes.keys()):
+        hash_value = packages_with_hashes[package]
+        content.append(f"{package} \\")
+        content.append(f"    --hash=sha256:{hash_value}")
+
+    return '\n'.join(content)
+
+def main() -> int:
+    """Main function to generate requirements file."""
+    parser = argparse.ArgumentParser(
+        description="Generate requirements file with complete dependency tree and hashes"
+    )
+    parser.add_argument(
+        'packages',
+        nargs='+',
+        help='Packages to install with version pins (e.g., safety==3.6.0)'
+    )
+    parser.add_argument(
+        '--platform',
+        default='linux_x86_64',
+        help='Platform to download packages for (default: linux_x86_64)'
+    )
+    parser.add_argument(
+        '--python-version',
+        default='310',
+        help='Python version to target (default: 310)'
+    )
+    parser.add_argument(
+        '--output', '-o',
+        help='Output file path (default: stdout)'
+    )
+    parser.add_argument(
+        '--comment',
+        help='Additional comment to include in the requirements file'
+    )
+
+    args = parser.parse_args()
+
+    # Validate package format
+    for package in args.packages:
+        if '==' not in package:
+            print(f"Error: Package '{package}' must include exact version with == (e.g., safety==3.6.0)", file=sys.stderr)
+            return 1
+
+    # Get all dependencies
+    dependencies = get_all_dependencies(args.packages)
+    if not dependencies:
+        print("Error: Could not resolve dependencies", file=sys.stderr)
+        return 1
+
+    print(f"Found {len(dependencies)} total dependencies: {dependencies}")
+
+    # Download and hash all packages
+    hashes = download_and_hash(dependencies, args.platform, args.python_version)
+    if not hashes:
+        print("Error: Could not download and hash packages", file=sys.stderr)
+        return 1
+
+    print(f"Generated hashes for {len(hashes)} packages")
+
+    # Generate requirements content
+    requirements_content = generate_requirements_content(hashes, args.comment)
+
+    # Output results
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(requirements_content)
+        print(f"Generated requirements file: {args.output}")
+    else:
+        print(requirements_content)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/http_api_tool/cli.py
+++ b/src/http_api_tool/cli.py
@@ -182,8 +182,17 @@ def verify(
 
 def _log_action_parameters(config: Dict[str, Any]) -> None:
     """Log the action parameters in a user-friendly format."""
+    from .verifier import HTTPAPITester
+
+    # Create a temporary verifier instance to use sanitization methods
+    temp_verifier = HTTPAPITester()
+
     print("📋 Configuration:")
-    print(f"   URL: {config.get('url', 'Not specified')}")
+    # Sanitize URL for logging
+    url = config.get("url", "Not specified")
+    if url != "Not specified":
+        url = temp_verifier.sanitize_url_for_logging(url)
+    print(f"   URL: {url}")
     print(f"   HTTP Method: {config.get('http_method', 'GET')}")
     print(f"   Service Name: {config.get('service_name', 'API Service')}")
     print(f"   Expected HTTP Code: {config.get('expected_http_code', '200')}")
@@ -197,10 +206,13 @@ def _log_action_parameters(config: Dict[str, Any]) -> None:
         print(f"   Regex Pattern: {config['regex']}")
     if config.get("request_body"):
         body = config["request_body"]
-        truncated_body = body[:100] + ("..." if len(body) > 100 else "")
-        print(f"   Request Body: {truncated_body}")
+        sanitized_body = temp_verifier.sanitize_request_body_for_logging(body, 100)
+        print(f"   Request Body: {sanitized_body}")
     if config.get("request_headers"):
-        print(f"   Custom Headers: {config['request_headers']}")
+        sanitized_headers = temp_verifier.sanitize_headers_for_logging(
+            config["request_headers"]
+        )
+        print(f"   Custom Headers: {sanitized_headers}")
     if config.get("auth_string"):
         print("   Authentication: *** (hidden)")
     max_time = config.get("max_response_time")


### PR DESCRIPTION
- Address pip install commands missing SHA pins for their version
- Add local test script to audit the repo to prevent future regressions
- Add test script to pre-commit linting hooks to guarantee compliance
- Updates logging subsystem with dedicated credential handling functions
- Prevent logging of credentials through log output of URLs, debugging, etc.
- Adds a warning that cURL debugging may expose credentials
- Add dedicated security scan/job to build-test.yaml
- Pin Python package installs in Dockerfile to hash values
- Create and document script to rebuild Dockerfile package hashes
- Remove call to external shasum command, use Python hashlib instead