### PR TITLE
Fix: Improve Docker build reliability/performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,8 +10,9 @@
 .github
 
 # Documentation
-README.md
+# README.md is needed for package metadata, exclude other markdown files
 *.md
+!README.md
 docs/
 
 # Test files and coverage reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,83 +1,122 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
+# UV version and checksums for secure installation with architecture-aware download
+# uv 0.8.4 - https://github.com/astral-sh/uv/releases/tag/0.8.4
+#
+# This Dockerfile automatically detects the target architecture (amd64/arm64) and
+# downloads the appropriate uv binary with checksum validation to prevent MITM
+# attacks.
+#
+# To override the version: docker build --build-arg UV_VERSION=0.8.3 .
+# Supports: linux/amd64 (Intel/AMD x86_64) and linux/arm64 (Apple Silicon/ARM64)
+ARG UV_VERSION=0.8.4
+ARG UV_CHECKSUM_AMD64=eb61d39fdc6ea21a6d00a24b50376102168240849c5022d3eba331f972ba3934
+ARG UV_CHECKSUM_ARM64=d42742a28ce161e72cce45c8c5621ee23317e30d461f595c382acf0f9b331f20
+
 # Multi-stage build for optimized caching and smaller final image
 FROM python:3.11-slim@sha256:7a3ed1226224bcc1fe5443262363d42f48cf832a540c1836ba8ccbeaadf8637c AS base
 
 # Install system dependencies and create app user in a single layer
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     curl \
-    docker.io \
     iproute2 \
     libcurl4-openssl-dev \
     libssl-dev \
     pkg-config \
-    && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && groupadd -r appuser \
     && useradd -r -g appuser appuser
 
 # Set working directory
 WORKDIR /app
 
+# UV installer stage - eliminates duplication across build stages
+FROM base AS uv-installer
+
+# Inherit UV version and checksums from global args
+ARG UV_VERSION
+ARG UV_CHECKSUM_AMD64
+ARG UV_CHECKSUM_ARM64
+ARG TARGETARCH
+
+# Install uv with architecture-aware download and checksum validation
+# Automatically selects the correct binary and checksum based on TARGETARCH
+RUN set -eu; \
+    case "${TARGETARCH}" in \
+        amd64) \
+            UV_ARCH="x86_64-unknown-linux-gnu"; \
+            UV_CHECKSUM="${UV_CHECKSUM_AMD64}"; \
+            ;; \
+        arm64) \
+            UV_ARCH="aarch64-unknown-linux-gnu"; \
+            UV_CHECKSUM="${UV_CHECKSUM_ARM64}"; \
+            ;; \
+        *) \
+            echo "Unsupported architecture: ${TARGETARCH}"; \
+            exit 1; \
+            ;; \
+    esac; \
+    curl -LsSf "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${UV_ARCH}.tar.gz" -o uv.tar.gz && \
+    echo "${UV_CHECKSUM}  uv.tar.gz" | sha256sum -c - && \
+    tar -xzf uv.tar.gz && \
+    mv "uv-${UV_ARCH}/uv" /usr/local/bin/ && \
+    mv "uv-${UV_ARCH}/uvx" /usr/local/bin/ && \
+    rm -rf uv.tar.gz "uv-${UV_ARCH}" && \
+    uv --version
+
 # Build stage for dependencies
 FROM base AS deps
 
-# Copy the requirements generation script
-COPY scripts/generate_requirements.py ./scripts/
+# Copy uv binaries from installer stage
+COPY --from=uv-installer /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=uv-installer /usr/local/bin/uvx /usr/local/bin/uvx
 
-# Generate requirements file dynamically for the current platform during build
-# This ensures correct hashes for the actual build environment
-# Note: Script will fallback to current platform if specific platform downloads fail
-RUN python3 scripts/generate_requirements.py \
-    --platform linux_x86_64 \
-    --python-version 311 \
-    --output requirements-docker.txt \
-    --comment "PDM and all its dependencies generated for Docker build environment" \
-    pdm==2.24.2 && \
-    echo "Generated requirements-docker.txt successfully" && \
-    head -10 requirements-docker.txt
+# Copy project files for dependency resolution
+COPY pyproject.toml README.md ./
 
-# Upgrade pip and install PDM with hash verification using pip cache
-# The --require-hashes mode is automatically enabled when hashes are present
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --upgrade pip && \
-    pip install -r requirements-docker.txt
+# Copy full source tree to permit version detection during uv lock
+COPY src/ src/
 
-# Copy project files and lock file for dependency resolution
-COPY pyproject.toml pdm.lock ./
+# Generate uv.lock from pyproject.toml during build to ensure freshness
+# This prevents stale package versions from being baked into the container
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv lock
 
-# Install dependencies only (without the package itself) using PDM cache
-RUN --mount=type=cache,target=/root/.cache/pdm \
-    pdm install --prod --no-isolation --no-self
+# Install dependencies using the freshly generated lock file
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
 
 # Production stage
 FROM base AS production
 
-# Copy the virtual environment from deps stage
+# Copy uv binaries from installer stage
+COPY --from=uv-installer /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=uv-installer /usr/local/bin/uvx /usr/local/bin/uvx
+
+# Copy the virtual environment and lock file from deps stage
 COPY --from=deps /app/.venv /app/.venv
+COPY --from=deps /app/uv.lock ./
 
 # Copy source code and project configuration
 COPY src/ src/
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
 
-# Fix the python symlinks (PDM creates circular symlinks) and install the package
-RUN rm -f /app/.venv/bin/python /app/.venv/bin/python3 /app/.venv/bin/python3.11 && \
-    ln -sf /usr/local/bin/python3.11 /app/.venv/bin/python && \
-    ln -sf /app/.venv/bin/python /app/.venv/bin/python3 && \
-    ln -sf /app/.venv/bin/python /app/.venv/bin/python3.11 && \
-    VENV_SITE_PACKAGES=$(/app/.venv/bin/python -c "import site; print(site.getsitepackages()[0])") && \
-    cp -r /app/src/http_api_tool "$VENV_SITE_PACKAGES/"
+# Install the package itself using proper uv installation for correct handling
+# of entry points, dependencies, and metadata
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
 
-# Note: For GitHub Actions Docker containers that need to write to environment files,
-# running as root is necessary due to file permission requirements.
+# Note: For GitHub Actions Docker containers that need to write to environment
+# files, running as root is necessary due to file permission requirements.
 # This is a common pattern in GitHub Actions Docker containers.
 
 # Activate the virtual environment permanently for the container
 ENV PATH="/app/.venv/bin:$PATH"
 ENV VIRTUAL_ENV="/app/.venv"
 
-# Set entrypoint to use the installed package from site-packages
+# Set entrypoint to use the installed package from virtual environment
 ENTRYPOINT ["/app/.venv/bin/python", "-m", "http_api_tool"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,45 @@ shell code implementations in GitHub actions.
 
 ## http-api-tool-docker
 
+A containerized version of the HTTP API test tool with secure,
+multi-architecture support.
+
+### Docker Security Features
+
+The Dockerfile implements these security best practices:
+
+- **Version Pinning**: uv binary version is explicitly pinned (0.8.4)
+- **Checksum Validation**: Downloads verify against SHA256 checksums to
+  prevent MITM attacks
+- **Multi-Architecture Support**: Automatically detects and downloads the
+  correct binary for:
+  - `linux/amd64` (Intel/AMD x86_64)
+  - `linux/arm64` (Apple Silicon/ARM64)
+
+### Building the Container
+
+```bash
+# Build for current platform
+docker build -t http-api-tool .
+
+# Build for specific platform
+docker build --platform linux/amd64 -t http-api-tool .
+docker build --platform linux/arm64 -t http-api-tool .
+
+# Override uv version
+docker build --build-arg UV_VERSION=0.8.5 -t http-api-tool .
+```
+
+### Container Usage
+
+```bash
+# Run the tool
+docker run --rm http-api-tool --help
+
+# Check uv version in container
+docker run --rm --entrypoint=/usr/local/bin/uv http-api-tool --version
+```
+
 ## Features
 
 - **Supported HTTP Methods**: Supports GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS


### PR DESCRIPTION
Swap commands in the Dockerfile and container build to use the uv dependency management tool. I have seen build failures related to crashes while managing Python packages, which primarily seem to be related to pip caching and cache content. Since uv uses its own cache subsystem, it seems likely this will sidestep the problem. A comparison of the container build time has shown a 22% improvement in the Docker container build time.

Also added the following behaviours:
- uv binary architecture installed conditional on Docker container
- uv binary is validated against the known release checksum
- Docker container builds validated for x64 and ARM64 platforms