### PR TITLE
CI: Enable Python 3.14 build/validation and fix PyPI publishing

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -211,8 +211,6 @@ jobs:
         with:
           egress-policy: 'audit'
 
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
       # Setup Python with pip caching for PyPI operations
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
@@ -320,8 +318,6 @@ jobs:
       - uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           egress-policy: 'audit'
-
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Setup Python with pip caching for PyPI operations
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Monitoring",
@@ -43,7 +44,7 @@ keywords = [
     "monitoring",
     "health-check",
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "pycurl>=7.45.0",
     "typer>=0.9.0",


### PR DESCRIPTION
- Enable Python 3.14 in pyproject.toml now environment updated
- Remove redundant checkout steps in Test/PyPI publishing steps