### PR TITLE
Fix: pre-commit.ci failures in mypy due to Typer library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,10 @@ strict_equality = true
 module = ["pycurl"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["http_api_tool.cli"]
+disallow_untyped_decorators = false
+
 [tool.bandit]
 exclude_dirs = ["tests"]
 skips = ["B101", "B601"]

--- a/src/http_api_tool/cli.py
+++ b/src/http_api_tool/cli.py
@@ -77,7 +77,7 @@ def _transform_localhost_url(url: str) -> str:
     return url
 
 
-@app.callback()  # type: ignore[misc]
+@app.callback()
 def main_callback(
     version: bool = typer.Option(
         False,
@@ -97,7 +97,7 @@ def main_callback(
     pass
 
 
-@app.command("test")  # type: ignore[misc]
+@app.command("test")
 def verify(
     url: str = typer.Option(..., help="URL of API server/interface to check"),
     auth_string: Optional[str] = typer.Option(


### PR DESCRIPTION
Set disallow_untyped_decorators to false in pyproject.toml for `http_api_tool.cli`
- Typer's decorators are actually properly typed in modern versions
- The strict `disallow_untyped_decorators` check is overly strict (for third-party decorators that preserve types)
- We still maintain all other strict type checking (untyped defs, incomplete defs, etc.)

Removed the `# type: ignore[misc]` comments from lines 80 and 100 in `src/http_api_tool/cli.py` since they're no longer needed.