### PR TITLE
Fix(coverage): Use package name in coverage source list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["src/http_api_tool"]
+source = ["http_api_tool"]
 omit = [
     "*/tests/*",
     "*/test_*",


### PR DESCRIPTION
## Summary

`[tool.coverage.run].source = ["src/http_api_tool"]` is a filesystem path. coverage.py treats `source` entries with a path separator as path filters. Under `lfreleng-actions/python-test-action` v1.1.x, which installs the project **non-editably** into `.venv`, the package lives at `.venv/lib/pythonX.Y/site-packages/http_api_tool/...` — a location the path filter never matches — so coverage reports `Total coverage: 0.00%` with a `No data was collected` warning, and any `--cov-fail-under` gate fails despite all tests passing.

## Fix

```diff
 [tool.coverage.run]
-source = ["src/http_api_tool"]
+source = ["http_api_tool"]
```

`coverage.py` treats single-token entries as import names and instruments the package wherever it is loaded from (including `site-packages`).

## Why this matters here in particular

`[tool.pytest.ini_options].addopts` uses a **bare `--cov`** (not `--cov=<pkg>`), so collection is scoped by `[tool.coverage.run].source`. The path-based value was therefore the only thing controlling what got measured, and it never matched the installed location.

The workflow is currently pinned to `python-test-action@v1.0.1` (which predates the bare-`--cov` injection that surfaced this class of bug), so this is preventive — it will break on the next Dependabot bump to v1.1.x without this fix.

Related fixes: [`lfreleng-actions/markdown-table-fixer#129`](https://github.com/lfreleng-actions/markdown-table-fixer/pull/129) (where the regression first surfaced) and [`lfreleng-actions/gha-workflow-linter#196`](https://github.com/lfreleng-actions/gha-workflow-linter/pull/196).