### PR TITLE
Fix(verifier): Resolve mypy unpacking error for pycurl args

### DIFF
--- a/src/http_api_tool/verifier.py
+++ b/src/http_api_tool/verifier.py
@@ -509,7 +509,8 @@ class HTTPAPITester:
             }
 
         except pycurl.error as e:
-            error_code, error_msg = e.args
+            error_code = e.args[0] if len(e.args) > 0 else 0
+            error_msg = e.args[1] if len(e.args) > 1 else str(e)
             return {
                 "success": False,
                 "http_code": 0,


### PR DESCRIPTION
## Summary

Fixes a mypy linting failure in `src/http_api_tool/verifier.py`:

```
src/http_api_tool/verifier.py:512: error: Need more than 1 value to unpack (2 expected)  [misc]
```

## Change

The `pycurl.error` exception's `args` attribute is typed as a generic
tuple, so mypy cannot guarantee it contains exactly two elements.
Replaced the direct tuple unpacking with explicit indexed access that
safely handles tuples of any length, defaulting sensibly when the
expected values are absent.

## Verification

- `uv run mypy src/http_api_tool/verifier.py` → Success
- All pre-commit hooks pass