### PR TITLE
Fix(deps): Remove uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,9 +191,3 @@ pythonVersion = "3.10"
 typeCheckingMode = "standard"
 reportMissingImports = "warning"
 reportUninitializedInstanceVariable = "warning"
-
-[tool.uv]
-# Supply-chain cooldown: do not resolve anything published in the last
-# 7 days (rolling window; uv records it as a relative span in uv.lock).
-# Requires uv >= 0.9.17 for the relative-duration ("7 days") form.
-exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "attrs"
 version = "25.4.0"


### PR DESCRIPTION
## Summary

The relative `exclude-newer = "7 days"` cooldown in `[tool.uv]` is baked
into `uv.lock` as `exclude-newer-span = "P7D"`. Dependabot's `uv` updater
re-resolves against that rolling window, regenerates a byte-identical
lockfile, and fails with **"Dependency file content did not change"** —
blocking automated and priority security updates.

## Change

- Remove the `exclude-newer` supply-chain cooldown from `pyproject.toml`.
- Regenerate `uv.lock` (drops the `[options]` `exclude-newer-span` block);
  deletion-only, no dependency versions moved.

The supply-chain auditing tool that originally recommended this cooldown
has updated its guidance — Dependabot cooldowns now cover the same
concern without breaking priority security fixes.

## Validation

- `uv lock` regenerates cleanly.
- `pre-commit` (including the test suite) passes.