### PR TITLE
Fix: resolve zizmor auditor persona findings

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: read  # Gather repository/PR metadata
     timeout-minutes: 5
     steps:
       # yamllint disable-line rule:line-length
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Gather repository metadata"
         id: repo-metadata
@@ -73,6 +74,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: 'Verify pushed tag'
         id: 'tag-validate'
@@ -135,6 +137,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Build Python project'
         id: 'python-build'
@@ -164,6 +168,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Test Python project [PYTEST]'
         # yamllint disable-line rule:line-length
@@ -191,6 +197,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Audit Python project'
         # yamllint disable-line rule:line-length
@@ -215,6 +223,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Generate SBOM"
         id: sbom
@@ -352,7 +362,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      packages: write
+      packages: write  # Push container images to GHCR
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
@@ -362,6 +372,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -482,6 +494,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download build artefacts'
         # yamllint disable-line rule:line-length
@@ -520,6 +534,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Check if release is already promoted'
         id: 'check-promoted'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,14 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write
+      actions: write  # Purge GitHub Actions caches via the API
     steps:
       - name: Purge all GitHub Actions caches
         run: |
           echo "🗑️ Purging all GitHub Actions caches for this repository..."
 
           # Get all cache keys using GitHub API
-          REPO="${{ github.repository }}"
+          REPO="$REPOSITORY"
 
           echo "Fetching cache list..."
           gh api -X GET "/repos/$REPO/actions/caches" --paginate | \
@@ -60,6 +60,7 @@ jobs:
           echo "✅ All caches purged successfully"
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
 
   # Build Docker image with comprehensive caching
   docker-build:
@@ -81,6 +82,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Set up Docker Buildx with caching
       - name: Set up Docker Buildx
@@ -128,6 +131,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Set up go-httpbin for testing
       - name: Setup go-httpbin HTTPS service
@@ -197,7 +202,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      packages: write
+      packages: write  # Push container images to GHCR
 
     steps:
       # Harden the runner
@@ -208,6 +213,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -284,6 +291,8 @@ jobs:
           egress-policy: 'audit'
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Setup Python with enhanced caching
       - name: Set up Python
@@ -331,6 +340,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Setup Python with comprehensive caching
       - name: Set up Python
@@ -380,6 +391,8 @@ jobs:
           egress-policy: 'audit'
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Setup Python with comprehensive caching
       - name: Set up Python
@@ -427,6 +440,8 @@ jobs:
           egress-policy: 'audit'
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Setup Python with comprehensive caching
       - name: Set up Python
@@ -548,6 +563,8 @@ jobs:
           egress-policy: 'audit'
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Start go-httpbin service for testing
       - name: Setup go-httpbin service
@@ -607,6 +624,8 @@ jobs:
           egress-policy: 'audit'
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Start go-httpbin service for testing
       - name: Setup go-httpbin service
@@ -720,6 +739,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Start go-httpbin service for testing
       - name: Setup go-httpbin service
@@ -778,7 +799,7 @@ jobs:
     if: github.event_name != 'pull_request'
     permissions:
       contents: read
-      packages: read
+      packages: read  # Pull published container images from GHCR
     timeout-minutes: 15
 
     steps:
@@ -789,6 +810,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -805,7 +828,7 @@ jobs:
       # Test Docker image functionality
       - name: Test Docker image functionality
         run: |
-          IMAGE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          IMAGE_TAG="${REGISTRY}/${IMAGE_NAME}:latest"
           echo "Testing published image: $IMAGE_TAG"
 
           # Test basic help command
@@ -821,7 +844,7 @@ jobs:
 
       - name: Test Docker image with go-httpbin
         run: |
-          IMAGE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          IMAGE_TAG="${REGISTRY}/${IMAGE_NAME}:latest"
           echo "Using image tag: $IMAGE_TAG"
 
           # Get service URL and CA bundle from go-httpbin action
@@ -860,6 +883,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Setup Python with caching
       - name: Set up Python

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-python-codeql.yaml@f412e6f89527da7611a5f4a5f861de86d98d3e9e # v0.7.0
     permissions:
-      security-events: write
-      # required to fetch internal or private CodeQL packs
-      packages: read
-      # only required for workflows in private repositories
-      actions: read
+      security-events: write  # Upload CodeQL results to code-scanning
+      packages: read  # Fetch internal or private CodeQL packs
+      actions: read  # Only required for workflows in private repositories
       contents: read

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -7,6 +7,8 @@
 # policy, and support documentation.
 
 name: "OpenSSF Scorecard"
+
+# yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
   # For Branch-Protection check. Only the default branch is supported. See
@@ -18,26 +20,19 @@ on:
     - cron: "50 4 * * 0"
   push:
     branches: ["main", "master"]
-    paths:
-      - "**"
-      - "!.github/**"
 
+# Declare default permissions as none.
 permissions: {}
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
 
 jobs:
   openssf-scorecard:
     name: "OpenSSF Scorecard"
     # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@f412e6f89527da7611a5f4a5f861de86d98d3e9e # v0.7.0
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267  # v0.7.2
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
+      contents: read  # Read repository contents (checkout, etc.)
+      # yamllint disable-line rule:line-length
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain Scorecard badge via OIDC
+      # Uncomment the permission below if installing in a private repository.
       # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,16 +20,26 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -42,10 +42,8 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-sonarqube-cloud.yaml@f412e6f89527da7611a5f4a5f861de86d98d3e9e # v0.7.0
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain a badge via OIDC
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read

--- a/action.yaml
+++ b/action.yaml
@@ -224,13 +224,15 @@ runs:
       if: inputs.deploy == 'docker'
       shell: bash
       working-directory: ${{ github.action_path }}
+      env:
+        RUN_ID: ${{ github.run_id }}
       run: |
         # Check if the image already exists (pre-loaded from artifact)
-        if docker image inspect http-api-tool:${{ github.run_id }} >/dev/null 2>&1; then
-          echo "::notice::Using pre-loaded Docker image http-api-tool:${{ github.run_id }}"
+        if docker image inspect "http-api-tool:${RUN_ID}" >/dev/null 2>&1; then
+          echo "::notice::Using pre-loaded Docker image http-api-tool:${RUN_ID}"
         else
-          echo "::notice::Building Docker image http-api-tool:${{ github.run_id }}"
-          docker build -f docker/Containerfile -t http-api-tool:${{ github.run_id }} .
+          echo "::notice::Building Docker image http-api-tool:${RUN_ID}"
+          docker build -f docker/Containerfile -t "http-api-tool:${RUN_ID}" .
         fi
 
     - name: Run http-api-tool via Docker
@@ -263,6 +265,7 @@ runs:
         INPUT_DEBUG: ${{ inputs.debug }}
         INPUT_FAIL_ON_TIMEOUT: ${{ inputs.fail_on_timeout }}
         GITHUB_ACTIONS: 'true'
+        RUN_ID: ${{ github.run_id }}
       run: |
         # Build volume mounts as an array so each '-v' entry is passed as a
         # single quoted argument and cannot inject extra docker flags/mounts.
@@ -330,10 +333,12 @@ runs:
           -e GITHUB_ACTIONS \
           -e GITHUB_OUTPUT \
           "${VOLUME_MOUNTS[@]}" \
-          http-api-tool:${{ github.run_id }}
+          "http-api-tool:${RUN_ID}"
 
     - name: Cleanup Docker image
       if: inputs.deploy == 'docker' && always()
       shell: bash
+      env:
+        RUN_ID: ${{ github.run_id }}
       run: |
-        docker rmi http-api-tool:${{ github.run_id }} || true
+        docker rmi "http-api-tool:${RUN_ID}" || true


### PR DESCRIPTION
## Summary

Resolves the zizmor **auditor** persona findings (`min-severity: low`)
that fail the organisation's required "Audit Workflows" gate and block
Dependabot pull requests from merging.

## Method

- **Boilerplate workflows** (`release-drafter`, `openssf-scorecard`)
  that carried findings were replaced byte-for-byte with the canonical
  versions from `actions-template`. This adds harden-runner block-mode
  egress via `harden-runner-block-action`, documented permission scopes
  (`undocumented-permissions`), and the current
  `reuse-openssf-scorecard.yaml` pin (v0.7.2).
- **Repository-specific workflows** (`build-test.yaml`,
  `build-test-release.yaml`, `codeql.yml`, `security-scans.yaml`) were
  adjusted in place to match the canonical patterns:
  - `persist-credentials: false` on every flagged `actions/checkout`
    step (`artipacked`) — no job in these workflows pushes commits or
    tags with the checkout credentials, so this is behaviour-preserving.
  - `${{ ... }}` expressions hoisted out of `run:` blocks into
    intermediate environment variables (`template-injection`), e.g.
    `github.repository` in the cache-purge job.
  - Explanatory trailing comments on permission scopes
    (`undocumented-permissions`).
- **Composite action** (`action.yaml`): the `${{ github.run_id }}`
  expression used to tag, inspect, and remove the local Docker image is
  now passed via a step-level `RUN_ID` environment variable and quoted
  in the shell (`template-injection`).

Verified with `zizmor --persona auditor --min-severity low` (clean),
with no action pin downgrades.
