### PR TITLE
Fix: Env-mediate expressions in run blocks

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -93,9 +93,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          STEPS_TAG_VALIDATE_OUTPUTS_TAG_NAME: ${{ steps.tag-validate.outputs.tag_name }}
         run: |
           # Ensure draft release exists
-          TAG="${{ steps.tag-validate.outputs.tag_name }}"
+          TAG="${STEPS_TAG_VALIDATE_OUTPUTS_TAG_NAME}"
           # Check if release exists and get its draft status
           if RELEASE_INFO=$(gh release view "$TAG" \
             --json isDraft 2>/dev/null); then
@@ -289,8 +290,8 @@ jobs:
             # Grype summary
             {
               echo "## SBOM Summary"
-              echo "SBOM count: ${{ steps.sbom.outputs.component_count }}"
-              echo "Tool used: ${{ steps.sbom.outputs.dependency_manager }}"
+              echo "SBOM count: ${STEPS_SBOM_OUTPUTS_COMPONENT_COUNT}"
+              echo "Tool used: ${STEPS_SBOM_OUTPUTS_DEPENDENCY_MANAGER}"
               echo ""
               echo "## Grype Vulnerability Scan"
               if [ -f grype-results.txt ]; then
@@ -303,6 +304,9 @@ jobs:
               echo "--- Grype scan results ---"
               cat grype-results.txt
             fi
+        env:
+          STEPS_SBOM_OUTPUTS_COMPONENT_COUNT: ${{ steps.sbom.outputs.component_count }}
+          STEPS_SBOM_OUTPUTS_DEPENDENCY_MANAGER: ${{ steps.sbom.outputs.dependency_manager }}
 
       # Fails the job if Grype found vulnerabilities, unless the
       # NO_BLOCK_AUDIT_FAIL repository variable is set to 'true'.
@@ -432,8 +436,11 @@ jobs:
       - name: Verify published image
         run: |
           echo "Docker image published successfully to GHCR"
-          echo "Version: ${{ needs.tag-validate.outputs.tag }}"
-          echo "Tags: ${{ steps.meta.outputs.tags }}"
+          echo "Version: ${NEEDS_TAG_VALIDATE_OUTPUTS_TAG}"
+          echo "Tags: ${STEPS_META_OUTPUTS_TAGS}"
+        env:
+          NEEDS_TAG_VALIDATE_OUTPUTS_TAG: ${{ needs.tag-validate.outputs.tag }}
+          STEPS_META_OUTPUTS_TAGS: ${{ steps.meta.outputs.tags }}
 
   pypi:
     name: 'Release PyPI Package'
@@ -542,8 +549,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          NEEDS_TAG_VALIDATE_OUTPUTS_TAG: ${{ needs.tag-validate.outputs.tag }}
         run: |
-          TAG="${{ needs.tag-validate.outputs.tag }}"
+          TAG="${NEEDS_TAG_VALIDATE_OUTPUTS_TAG}"
           if gh release view "$TAG" --json isDraft --jq '.isDraft' \
               2>/dev/null | grep -q "false"; then
             echo "Release $TAG is already promoted, skipping promotion"
@@ -570,7 +578,8 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          NEEDS_TAG_VALIDATE_OUTPUTS_TAG: ${{ needs.tag-validate.outputs.tag }}
         run: |
-          TAG="${{ needs.tag-validate.outputs.tag }}"
+          TAG="${NEEDS_TAG_VALIDATE_OUTPUTS_TAG}"
           RELEASE_URL=$(gh release view "$TAG" --json url --jq '.url')
           echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -102,11 +102,12 @@ jobs:
           tags: http-api-tool:test
           build-args: |
             VERSION=0.0.0.dev0
+          # yamllint disable rule:line-length
           cache-from: |
-            # yamllint disable-line rule:line-length
             ${{ github.event_name == 'workflow_dispatch' && inputs.bust_cache == true && 'type=gha,scope=docker-build-never-exists' || 'type=gha,scope=docker-build' }}
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-base
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-deps
+          # yamllint enable rule:line-length
           cache-to: type=gha,mode=max,scope=docker-build
           no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.bust_cache == true }}
           labels: |
@@ -255,11 +256,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=0.0.0.dev0
+          # yamllint disable rule:line-length
           cache-from: |
-            # yamllint disable-line rule:line-length
             ${{ github.event_name == 'workflow_dispatch' && inputs.bust_cache == true && 'type=gha,scope=docker-publish-never-exists' || 'type=gha,scope=docker-publish' }}
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-base
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-deps
+          # yamllint enable rule:line-length
           no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.bust_cache == true }}
           cache-to: |
             type=gha,mode=max,scope=docker-publish
@@ -269,7 +271,9 @@ jobs:
       - name: Verify published image
         run: |
           echo "Image published successfully to GHCR"
-          echo "Tags: ${{ steps.meta.outputs.tags }}"
+          echo "Tags: ${STEPS_META_OUTPUTS_TAGS}"
+        env:
+          STEPS_META_OUTPUTS_TAGS: ${{ steps.meta.outputs.tags }}
 
   # Python build for additional testing (runs in parallel with container pipeline)
   python-build:
@@ -311,6 +315,7 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
+          # yamllint disable-line rule:line-length
           key: uv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
@@ -424,7 +429,6 @@ jobs:
           python_version: "${{ matrix.python-version }}"
 
 
-
   # CLI integration tests (after container pipeline)
   cli-tests:
     name: 'CLI Integration Tests'
@@ -460,6 +464,7 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
+          # yamllint disable-line rule:line-length
           key: uv-cli-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
           restore-keys: |
             uv-cli-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
@@ -491,8 +496,8 @@ jobs:
       - name: Test CLI with various scenarios
         run: |
           # Use the HTTPS service URL and CA bundle from the go-httpbin action
-          SERVICE_URL="${{ steps.go-httpbin.outputs.service-url }}"
-          CA_BUNDLE="${{ steps.go-httpbin.outputs.ca-cert-path }}"
+          SERVICE_URL="${STEPS_GO_HTTPBIN_OUTPUTS_SERVICE_URL}"
+          CA_BUNDLE="${STEPS_GO_HTTPBIN_OUTPUTS_CA_CERT_PATH}"
 
           echo "Testing with service URL: $SERVICE_URL"
           echo "Using CA bundle: $CA_BUNDLE"
@@ -532,6 +537,9 @@ jobs:
             --expected-http-code 401 \
             --ca-bundle-path "$CA_BUNDLE" \
             --debug || echo "Expected 401 for unauth request"
+        env:
+          STEPS_GO_HTTPBIN_OUTPUTS_SERVICE_URL: ${{ steps.go-httpbin.outputs.service-url }}
+          STEPS_GO_HTTPBIN_OUTPUTS_CA_CERT_PATH: ${{ steps.go-httpbin.outputs.ca-cert-path }}
 
       - name: Test CLI error handling
         run: |
@@ -640,7 +648,7 @@ jobs:
         id: test-urls
         run: |
           # Get the gateway IP URL from go-httpbin
-          GATEWAY_URL="${{ steps.go-httpbin.outputs.service-url }}"
+          GATEWAY_URL="${STEPS_GO_HTTPBIN_OUTPUTS_SERVICE_URL}"
           echo "Gateway URL from action: $GATEWAY_URL"
 
           # For docker mode, we can use the gateway URL directly
@@ -657,6 +665,8 @@ jobs:
           echo "host-url=${HOST_URL}" >> "$GITHUB_OUTPUT"
           echo "Host URL for uvx tests: $HOST_URL"
           echo "✅ Prepared test URLs for both deployment modes"
+        env:
+          STEPS_GO_HTTPBIN_OUTPUTS_SERVICE_URL: ${{ steps.go-httpbin.outputs.service-url }}
 
       - name: Test uvx deployment with host URL
         uses: ./
@@ -691,7 +701,6 @@ jobs:
         run: |
           echo "✅ Docker mode successfully connected using gateway IP"
           echo "Docker containers use the gateway IP to access host services"
-
 
 
       - name: Test uvx with POST request
@@ -848,8 +857,8 @@ jobs:
           echo "Using image tag: $IMAGE_TAG"
 
           # Get service URL and CA bundle from go-httpbin action
-          SERVICE_URL="${{ steps.go-httpbin.outputs.service-url }}"
-          CA_BUNDLE="${{ steps.go-httpbin.outputs.ca-cert-path }}"
+          SERVICE_URL="${STEPS_GO_HTTPBIN_OUTPUTS_SERVICE_URL}"
+          CA_BUNDLE="${STEPS_GO_HTTPBIN_OUTPUTS_CA_CERT_PATH}"
 
           # Test the http-api-tool against go-httpbin with HTTPS
           docker run --rm --network host \
@@ -860,6 +869,9 @@ jobs:
             --ca-bundle-path "/tmp/ca-bundle.pem" \
             --debug \
             --retries 3
+        env:
+          STEPS_GO_HTTPBIN_OUTPUTS_SERVICE_URL: ${{ steps.go-httpbin.outputs.service-url }}
+          STEPS_GO_HTTPBIN_OUTPUTS_CA_CERT_PATH: ${{ steps.go-httpbin.outputs.ca-cert-path }}
 
       - name: Clean up test containers
         if: always()


### PR DESCRIPTION
## Why

`zizmor`'s `template-injection` audit reports GitHub expressions that expand directly inside `run:` blocks. The expansion happens *before* the shell sees the script, so a value carrying shell syntax becomes code rather than data.

Each expression now reaches the shell through the step environment instead. These findings predate the change to the organisation `zizmor` floor (`low` → `informational`); they were simply below the old threshold.

## Please review the diff carefully

The transformation is not purely mechanical. Swapping `${{ expr }}` for `${VAR}` **changes the quoting rules**, because the original was substituted by GitHub before the shell ran and the replacement is an ordinary shell variable. Three contexts silently stop working:

| Context | Before | After |
| ------- | ------ | ----- |
| `var='${{ expr }}'` | substituted by GitHub | **literal string** |
| `echo 'text ${{ expr }}'` | substituted by GitHub | **literal string** |
| `cat <<'EOF'` … `${{ expr }}` | substituted by GitHub | **literal string** |

`shellcheck` catches the first two. **It does not catch the heredoc case.** That one was found in `url-validity-action`, where 27 references would have rendered the job summary as variable names instead of results.

## What was verified before raising this

- `zizmor --persona auditor --min-severity informational` — no findings
- `actionlint` (including shellcheck) — clean
- `yamllint` — clean
- A purpose-built audit for generated variables landing in single quotes or quoted heredocs — clean. It was validated by confirming it detects 33 such problems in the unrepaired output for `url-validity-action`.
- Diff restricted to workflow and action definitions; no `dependabot.yml` or version-pin comment changes rode along

## Note on the generated names

Where `zizmor`'s names push a line past the length limit, the line carries a `yamllint disable-line` directive. Shortening them was rejected: the short forms are unique only *within* one `env:` block, so a global rewrite merges distinct variables and leaves dangling references — verified by observing exactly that failure.
