### PR TITLE
Chore: Pin ruff rule selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,3 +191,54 @@ pythonVersion = "3.10"
 typeCheckingMode = "standard"
 reportMissingImports = "warning"
 reportUninitializedInstanceVariable = "warning"
+
+# Pin the ruff rule set explicitly.
+#
+# Without a `select`, ruff applies its *default* rule set, and that
+# default is not stable across releases:
+#
+#     ruff 0.15.22 ->  59 rules across  2 categories (E, F)
+#     ruff 0.16.0  -> 413 rules across 38 categories
+#
+# A routine pre-commit autoupdate crossing that boundary changed which
+# rules run and broke repositories across this organisation, on code
+# nobody had touched.
+#
+# The selection below is deliberately narrow: it is exactly the rule set
+# this repository already satisfies, so pinning changes no behaviour
+# today. Widening it to the organisation superset
+# ("E", "W", "F", "I", "B", "C4", "UP") is worthwhile but is a code
+# change, not a configuration one: it currently reports 22 findings,
+# 14 of them auto-fixable, with 6 B904 (raise-without-from) needing
+# review by hand. That belongs in its own reviewed pull request rather
+# than riding along with a version bump.
+#
+# Note that this pins the rule set at CATEGORY level, not rule level.
+# Ruff selectors are prefixes, so a future release adding new E* or F*
+# rules would enable them here automatically. Pinning every rule code
+# individually would be exhaustive and unmaintainable; the aim is to
+# bound the blast radius, reducing "413 rules across 38 categories"
+# back to two, not to freeze the set outright.
+#
+# `line-length` and `target-version` are intentionally left unset so
+# ruff's own defaults continue to apply unchanged.
+
+[tool.ruff.lint]
+select = ["E", "F"]
+
+ignore = [
+  "E501", # line-too-long: the formatter owns line length
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Test suites legitimately break rules that matter in library code.
+#
+# None of these codes is reachable under the current `select`, and only
+# B-prefixed ones would be reachable under the organisation superset.
+# They are listed anyway so that a later widening beyond that superset,
+# to "S", "ARG" or "PL", does not immediately flag every test module.
+# PLR0917 is the concrete case already seen elsewhere: tests stacking
+# @patch decorators cannot satisfy it, because unittest.mock injects
+# its mocks positionally, so a keyword-only signature is impossible
+# rather than merely inconvenient.
+"tests/**/*.py" = ["S101", "ARG", "PLR0913", "PLR0917", "PLR2004"]


### PR DESCRIPTION
## Why

Without a `select`, ruff applies its *default* rule set, and that default is not stable across releases:

```
ruff 0.15.22 ->  59 rules across  2 categories (E, F)
ruff 0.16.0  -> 413 rules across 38 categories
```

A routine `pre-commit` autoupdate crossing that boundary changes which rules run, on code nobody has touched. That is exactly what fails the open autoupdate PR #333 here.

## Deliberately narrow

The selection is precisely the rule set this repository **already satisfies**, so pinning changes no behaviour today: both ruff 0.15.22 and 0.16.0 report all checks passing.

Adopting the wider organisation superset (`E, W, F, I, B, C4, UP`) is worthwhile but belongs in its own reviewed change — it currently reports **22 findings, 14 auto-fixable**, with 6 `B904` raise-without-from sites needing judgement about which exception context to preserve. Folding an error-handling refactor into a configuration chore would obscure both.
