### PR TITLE
Refactor: Split verifier, clear aislop findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,14 +56,10 @@ repos:
     rev: 7c55798a78262d14b2074abf623d8a992ebb70d4  # frozen: v0.16.2
     hooks:
       - id: ruff
-        # Currently only src and tests contain Python files
-        # Pattern can be expanded if scripts or other Python directories are added
-        files: ^(src|tests)/.+\.py$
+        files: ^(src|tests|scripts)/.+\.py$
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-        # Currently only src and tests contain Python files
-        # Pattern can be expanded if scripts or other Python directories are added
-        files: ^(src|tests)/.+\.py$
+        files: ^(src|tests|scripts)/.+\.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0

--- a/scripts/check-pip-security.py
+++ b/scripts/check-pip-security.py
@@ -21,9 +21,7 @@ def main() -> int:
         description="Check GitHub workflows for pip install commands without SHA hashes"
     )
     parser.add_argument(
-        "files",
-        nargs="*",
-        help="Files to check (if empty, checks all workflow files)"
+        "files", nargs="*", help="Files to check (if empty, checks all workflow files)"
     )
 
     args = parser.parse_args()
@@ -33,9 +31,11 @@ def main() -> int:
         files_to_check = [Path(f) for f in args.files]
     else:
         # Default to checking all workflow files
-        workflow_dir = Path('.github/workflows')
+        workflow_dir = Path(".github/workflows")
         if workflow_dir.exists():
-            files_to_check = list(workflow_dir.glob('*.yml')) + list(workflow_dir.glob('*.yaml'))
+            files_to_check = list(workflow_dir.glob("*.yml")) + list(
+                workflow_dir.glob("*.yaml")
+            )
         else:
             print("No .github/workflows directory found", file=sys.stderr)
             return 1
@@ -43,7 +43,7 @@ def main() -> int:
     violation_count = 0
 
     for file_path in files_to_check:
-        if not file_path.exists() or file_path.suffix not in ['.yml', '.yaml']:
+        if not file_path.exists() or file_path.suffix not in [".yml", ".yaml"]:
             continue
 
         violations = check_file_for_violations(file_path)
@@ -60,7 +60,7 @@ def main() -> int:
 def check_file_for_violations(file_path: Path) -> int:
     """Check a single file for pip install violations."""
     try:
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
     except (OSError, UnicodeDecodeError) as e:
         print(f"Warning: Could not read {file_path}: {e}", file=sys.stderr)
@@ -74,15 +74,15 @@ def check_file_for_violations(file_path: Path) -> int:
         line = lines[i].strip()
 
         # Check for pip install commands
-        if re.search(r'\bpip\s+.*install\b', line):
+        if re.search(r"\bpip\s+.*install\b", line):
             # Collect full command (may span multiple lines)
             command_lines = [line]
-            while line.endswith('\\') and i + 1 < len(lines):
+            while line.endswith("\\") and i + 1 < len(lines):
                 i += 1
                 line = lines[i].strip()
                 command_lines.append(line)
 
-            full_command = ' '.join(command_lines)
+            full_command = " ".join(command_lines)
 
             if is_violation(full_command):
                 violations += 1
@@ -99,10 +99,10 @@ def is_violation(command: str) -> bool:
     """Check if a pip install command violates security requirements."""
     # Skip safe patterns
     safe_patterns = [
-        r'pip\s+.*install\s+--upgrade\s+pip\s*$',  # pip upgrade itself
-        r'pip\s+.*install\s+-r\s+',  # requirements file
-        r'pip\s+.*install\s+-e\s+',  # editable installs
-        r'pip\s+.*install\s+\.\s*$',  # current directory
+        r"pip\s+.*install\s+--upgrade\s+pip\s*$",  # pip upgrade itself
+        r"pip\s+.*install\s+-r\s+",  # requirements file
+        r"pip\s+.*install\s+-e\s+",  # editable installs
+        r"pip\s+.*install\s+\.\s*$",  # current directory
     ]
 
     for pattern in safe_patterns:
@@ -110,8 +110,8 @@ def is_violation(command: str) -> bool:
             return False
 
     # Check for package with version constraints
-    has_version = re.search(r'\b[a-zA-Z0-9_-]+\s*[><=!~]+\s*[0-9.]+', command)
-    has_hash = '--hash=' in command or '--hash ' in command
+    has_version = re.search(r"\b[a-zA-Z0-9_-]+\s*[><=!~]+\s*[0-9.]+", command)
+    has_hash = "--hash=" in command or "--hash " in command
 
     return bool(has_version and not has_hash)
 
@@ -120,11 +120,15 @@ def print_security_guidance() -> None:
     """Print security guidance for fixing violations."""
     print()
     print("🔒 Security Requirement:")
-    print("All pip install commands with version constraints must use SHA256 hash pinning")
+    print(
+        "All pip install commands with version constraints must use SHA256 hash pinning"
+    )
     print("to prevent supply chain attacks and ensure deterministic builds.")
     print()
     print("Recommended approach:")
-    print("  Use the provided script to generate requirements with complete dependency tree:")
+    print(
+        "  Use the provided script to generate requirements with complete dependency tree:"
+    )
     print("  python3 scripts/generate_requirements.py \\")
     print("    --platform linux_x86_64 \\")
     print("    --python-version 311 \\")
@@ -140,7 +144,9 @@ def print_security_guidance() -> None:
     print("  pip install --require-hashes -r requirements.txt")
     print()
     print("Note: --hash is a per-requirement option for requirements files only,")
-    print("      not a command-line option for 'pip install'. When using --require-hashes,")
+    print(
+        "      not a command-line option for 'pip install'. When using --require-hashes,"
+    )
     print("      ALL dependencies (including transitive ones) must have hashes.")
     print()
     print("For more information, see:")

--- a/src/http_api_tool/cli.py
+++ b/src/http_api_tool/cli.py
@@ -17,6 +17,12 @@ from urllib.parse import urlparse, urlunparse
 import typer
 
 from ._version import __version__
+from .reporting import ActionReporter
+from .sanitize import (
+    sanitize_headers_for_logging,
+    sanitize_request_body_for_logging,
+    sanitize_url_for_logging,
+)
 from .verifier import HTTPAPITester
 
 
@@ -208,56 +214,47 @@ def verify(
 
 def _log_action_parameters(config: dict[str, Any]) -> None:
     """Log the action parameters in a user-friendly format."""
-    from .verifier import HTTPAPITester
-
-    # Create a temporary verifier instance to use sanitization methods
-    temp_verifier = HTTPAPITester()
-
-    print("📋 Configuration:")
-    # Sanitize URL for logging
+    typer.echo("📋 Configuration:")
     url = config.get("url", "Not specified")
     if url != "Not specified":
-        url = temp_verifier.sanitize_url_for_logging(url)
-    print(f"   URL: {url}")
-    print(f"   HTTP Method: {config.get('http_method', 'GET')}")
-    print(f"   Service Name: {config.get('service_name', 'API Service')}")
-    print(f"   Expected HTTP Code: {config.get('expected_http_code', '200')}")
-    print(f"   Retries: {config.get('retries', '3')}")
-    print(f"   Timeout: {config.get('curl_timeout', '5')} seconds")
-    print(f"   SSL Verification: {config.get('verify_ssl', 'true')}")
-    print(f"   Follow Redirects: {config.get('follow_redirects', 'true')}")
+        url = sanitize_url_for_logging(url)
+    typer.echo(f"   URL: {url}")
+    typer.echo(f"   HTTP Method: {config.get('http_method', 'GET')}")
+    typer.echo(f"   Service Name: {config.get('service_name', 'API Service')}")
+    typer.echo(f"   Expected HTTP Code: {config.get('expected_http_code', '200')}")
+    typer.echo(f"   Retries: {config.get('retries', '3')}")
+    typer.echo(f"   Timeout: {config.get('curl_timeout', '5')} seconds")
+    typer.echo(f"   SSL Verification: {config.get('verify_ssl', 'true')}")
+    typer.echo(f"   Follow Redirects: {config.get('follow_redirects', 'true')}")
 
     # Show optional parameters if they're set
     if config.get("regex"):
-        print(f"   Regex Pattern: {config['regex']}")
+        typer.echo(f"   Regex Pattern: {config['regex']}")
     if config.get("request_body"):
-        body = config["request_body"]
-        sanitized_body = temp_verifier.sanitize_request_body_for_logging(body, 100)
-        print(f"   Request Body: {sanitized_body}")
+        sanitized_body = sanitize_request_body_for_logging(config["request_body"], 100)
+        typer.echo(f"   Request Body: {sanitized_body}")
     if config.get("request_headers"):
-        sanitized_headers = temp_verifier.sanitize_headers_for_logging(
-            config["request_headers"]
-        )
-        print(f"   Custom Headers: {sanitized_headers}")
+        sanitized_headers = sanitize_headers_for_logging(config["request_headers"])
+        typer.echo(f"   Custom Headers: {sanitized_headers}")
     if config.get("auth_string"):
-        print("   Authentication: *** (hidden)")
+        typer.echo("   Authentication: *** (hidden)")
     max_time = config.get("max_response_time")
     if max_time and float(max_time) > 0:
-        print(f"   Max Response Time: {max_time} seconds")
+        typer.echo(f"   Max Response Time: {max_time} seconds")
 
     debug_enabled = config.get("debug", "false").lower() == "true"
-    print(f"   Debug Mode: {debug_enabled}")
-    print("=" * 50)
-    print()
+    typer.echo(f"   Debug Mode: {debug_enabled}")
+    typer.echo("=" * 50)
+    typer.echo()
 
 
 def run_github_action() -> None:
     """Run in GitHub Actions mode."""
-    verifier = HTTPAPITester()
+    reporter = ActionReporter()
+    verifier = HTTPAPITester(reporter)
 
-    # Print startup banner
-    print("🚀 HTTP API Tool")
-    print("=" * 50)
+    typer.echo("🚀 HTTP API Tool")
+    typer.echo("=" * 50)
 
     # Map GitHub Action inputs to function parameters
     config = {}
@@ -306,7 +303,6 @@ def run_github_action() -> None:
         "show_header_json": "false",
     }
 
-    # Get inputs from environment with defaults
     for param, env_var in input_mappings.items():
         value = os.environ.get(env_var, defaults.get(param))
         if value is not None:
@@ -316,32 +312,27 @@ def run_github_action() -> None:
     if "url" in config:
         config["url"] = _transform_localhost_url(config["url"])
 
-    # Log the configuration
     _log_action_parameters(config)
 
     try:
         result = verifier.test_api(**config)
 
-        # Write outputs to GitHub Actions
         for key, value in result.items():
-            # Convert boolean values to lowercase strings for GitHub Actions
-            # Note: result dict contains mixed types: bool, int, float, str
-            value_any: Any = value  # Help MyPy understand mixed types
+            # Note: result holds mixed types (bool, int, float, str), and
+            # GitHub Actions expects lowercase booleans.
+            value_any: Any = value
             if isinstance(value_any, bool):
                 output_value = str(value_any).lower()
             else:
-                # Handle non-boolean values (int, float, str, etc.)
                 output_value = str(value_any)
-            verifier.write_github_output(key, output_value)
+            reporter.write_github_output(key, output_value)
 
-        # Show completion message
-        print()
-        print("✅ HTTP API Tool")
-        print("=" * 50)
+        typer.echo()
+        typer.echo("✅ HTTP API Tool")
+        typer.echo("=" * 50)
 
     except Exception as e:
-        # Only log once to avoid duplication
-        print(f"Error: {e}", file=sys.stderr)
+        typer.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
 

--- a/src/http_api_tool/curl_client.py
+++ b/src/http_api_tool/curl_client.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+pycurl handle construction and request execution.
+
+The functions here own everything that touches libcurl, so the retry and
+reporting logic in :mod:`http_api_tool.verifier` stays free of transport
+detail.
+"""
+
+import json
+import os
+import re
+from io import BytesIO
+from typing import Any
+
+import pycurl
+
+from .reporting import ActionReporter
+from .sanitize import extract_url_credentials, sanitize_headers_for_logging
+
+# cURL exit code mapped to its message and whether retrying is pointless.
+CURL_ERRORS: dict[int, tuple[str, bool]] = {
+    1: ("Error: Unsupported protocol", False),
+    3: ("Error: URL malformed", False),
+    5: ("Error: Couldn't resolve proxy", False),
+    6: ("Error: Couldn't resolve host", False),
+    7: ("Error: Failed to connect to host", False),
+    28: ("Error: Request timeout", False),
+    35: ("Error: SSL connect error", True),
+    51: ("Error: The peer's SSL certificate is not OK", True),
+    52: ("Error: Nothing was returned from the server", False),
+    60: ("Error: SSL self-signed certificate", True),
+}
+
+
+def describe_curl_error(error_code: int) -> tuple[str, bool]:
+    """Return the message for a cURL exit code, and whether it is fatal."""
+    return CURL_ERRORS.get(
+        error_code,
+        (f"Error: cURL encountered an error (code {error_code})", False),
+    )
+
+
+def _configure_tls(
+    curl: pycurl.Curl, reporter: ActionReporter, config: dict[str, Any]
+) -> None:
+    """Apply certificate verification and CA bundle settings."""
+    if not config["verify_ssl"]:
+        curl.setopt(pycurl.SSL_VERIFYPEER, 0)
+        curl.setopt(pycurl.SSL_VERIFYHOST, 0)
+        reporter.log("Warning: SSL certificate verification disabled", "⚠️")
+        return
+
+    ca_bundle_path = config.get("ca_bundle_path")
+    if not ca_bundle_path:
+        return
+    if os.path.isfile(ca_bundle_path):
+        curl.setopt(pycurl.CAINFO, ca_bundle_path)
+        reporter.debug_log(f"Using custom CA bundle: {ca_bundle_path}")
+    else:
+        reporter.log(f"Warning: CA bundle file not found: {ca_bundle_path}", "⚠️")
+
+
+def _configure_auth(
+    curl: pycurl.Curl, reporter: ActionReporter, config: dict[str, Any]
+) -> None:
+    """Apply credentials taken from the config or embedded in the URL."""
+    auth_string = config.get("auth_string")
+    if not auth_string:
+        username, password = extract_url_credentials(config["url"])
+        if username is not None:
+            auth_string = f"{username}:{password}"
+
+    if not auth_string:
+        return
+    reporter.mask_credentials_from_auth_string(auth_string)
+    reporter.log("Authentication credentials provided", "💬")
+    curl.setopt(pycurl.USERPWD, auth_string)
+
+
+def _build_headers(reporter: ActionReporter, config: dict[str, Any]) -> list[str]:
+    """Assemble the request header lines from the config."""
+    headers = []
+    if config.get("request_body"):
+        headers.append(f"Content-Type: {config['content_type']}")
+
+    if not config.get("request_headers"):
+        return headers
+
+    try:
+        custom_headers = json.loads(config["request_headers"])
+    except json.JSONDecodeError:
+        raise ValueError("Error: Invalid JSON in request_headers ❌") from None
+
+    headers.extend(f"{key}: {value}" for key, value in custom_headers.items())
+    sanitized = sanitize_headers_for_logging(config["request_headers"])
+    reporter.debug_log(f"Added custom headers: {sanitized}")
+    return headers
+
+
+def _warn_about_verbose_credentials(
+    reporter: ActionReporter, config: dict[str, Any]
+) -> None:
+    """Warn that pycurl's verbose mode prints credentials in clear text."""
+    username, _ = extract_url_credentials(config["url"])
+    if username is None and not config.get("auth_string"):
+        return
+    reporter.log("⚠️  Warning: Debug mode enabled with authentication credentials.", "⚠️")
+    reporter.log("⚠️  pycurl verbose output may expose credentials in logs.", "⚠️")
+    reporter.log("⚠️  Disable debug mode for production use.", "⚠️")
+
+
+def create_curl_handle(reporter: ActionReporter, **config: Any) -> pycurl.Curl:
+    """Build a configured pycurl handle for a single request."""
+    curl = pycurl.Curl()
+
+    curl.setopt(pycurl.URL, config["url"])
+    curl.setopt(pycurl.TIMEOUT, config["curl_timeout"])
+    curl.setopt(pycurl.CUSTOMREQUEST, config["http_method"])
+    curl.setopt(pycurl.VERBOSE, config["debug"])
+    if config["debug"]:
+        _warn_about_verbose_credentials(reporter, config)
+
+    _configure_tls(curl, reporter, config)
+
+    if not config["connection_reuse"]:
+        curl.setopt(pycurl.FRESH_CONNECT, 1)
+        curl.setopt(pycurl.FORBID_REUSE, 1)
+
+    if config["follow_redirects"]:
+        curl.setopt(pycurl.FOLLOWLOCATION, 1)
+    else:
+        curl.setopt(pycurl.MAXREDIRS, 0)
+
+    _configure_auth(curl, reporter, config)
+
+    headers = _build_headers(reporter, config)
+    if headers:
+        curl.setopt(pycurl.HTTPHEADER, headers)
+
+    if config.get("request_body"):
+        body_data = config["request_body"].encode("utf-8")
+        curl.setopt(pycurl.POSTFIELDS, body_data)
+        curl.setopt(pycurl.POSTFIELDSIZE, len(body_data))
+
+    # Nothing downstream reads the body in this combination, so ask for
+    # headers alone.
+    if (
+        not config.get("regex")
+        and not config.get("include_response_body", True)
+        and not config["debug"]
+    ):
+        curl.setopt(pycurl.NOBODY, 1)
+
+    return curl
+
+
+def perform_request(curl: pycurl.Curl) -> dict[str, Any]:
+    """Run a prepared request and return its response and metrics."""
+    response_buffer = BytesIO()
+    header_buffer = BytesIO()
+
+    curl.setopt(pycurl.WRITEDATA, response_buffer)
+    curl.setopt(pycurl.HEADERFUNCTION, header_buffer.write)
+
+    try:
+        curl.perform()
+    except pycurl.error as error:
+        error_code = error.args[0] if len(error.args) > 0 else 0
+        error_msg = error.args[1] if len(error.args) > 1 else str(error)
+        return {
+            "success": False,
+            "http_code": 0,
+            "total_time": 0,
+            "connect_time": 0,
+            "body_size": 0,
+            "header_size": 0,
+            "response_body": b"",
+            "response_headers": "",
+            "header_json": "{}",
+            "curl_error": (error_code, error_msg),
+        }
+
+    response_headers = header_buffer.getvalue().decode("utf-8", errors="ignore")
+    return {
+        "success": True,
+        "http_code": int(curl.getinfo(pycurl.RESPONSE_CODE)),
+        "total_time": curl.getinfo(pycurl.TOTAL_TIME),
+        "connect_time": curl.getinfo(pycurl.CONNECT_TIME),
+        "body_size": int(curl.getinfo(pycurl.SIZE_DOWNLOAD)),
+        "header_size": int(curl.getinfo(pycurl.HEADER_SIZE)),
+        "response_body": response_buffer.getvalue(),
+        "response_headers": response_headers,
+        "header_json": parse_headers_to_json(response_headers),
+        "curl_error": None,
+    }
+
+
+def parse_headers_to_json(headers_text: str) -> str:
+    """Render raw HTTP response headers as a compact JSON object."""
+    if not headers_text.strip():
+        return "{}"
+
+    headers_dict = {}
+    for raw_line in headers_text.strip().split("\n"):
+        line = raw_line.strip()
+        if not line or line.startswith("HTTP/"):
+            continue
+        if ":" in line:
+            key, value = line.split(":", 1)
+            headers_dict[key.strip()] = value.strip()
+
+    try:
+        return json.dumps(headers_dict, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return "{}"
+
+
+def check_regex_match(response_body: bytes, regex_pattern: str) -> bool:
+    """Report whether the response body matches the given pattern."""
+    if not regex_pattern:
+        return True
+
+    try:
+        body_text = response_body.decode("utf-8", errors="ignore")
+        return bool(re.search(regex_pattern, body_text))
+    except (re.error, UnicodeDecodeError, AttributeError):
+        return False

--- a/src/http_api_tool/reporting.py
+++ b/src/http_api_tool/reporting.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Console, step-summary, and workflow-command output.
+
+``ActionReporter`` owns every channel the tool writes to: stdout for the
+operator, ``GITHUB_STEP_SUMMARY`` for the job summary, ``GITHUB_OUTPUT``
+for downstream steps, and stdout again for runner workflow commands.
+"""
+
+import os
+import sys
+
+import typer
+
+
+class ActionReporter:
+    """Write operator output and GitHub Actions side channels."""
+
+    def __init__(self, debug: bool = False) -> None:
+        self.debug: bool = debug
+        self.step_summary_file: str | None = os.environ.get("GITHUB_STEP_SUMMARY")
+        self.github_output_file: str | None = os.environ.get("GITHUB_OUTPUT")
+
+    def log(self, message: str, emoji: str = "") -> None:
+        """Write a message to stdout with an optional trailing emoji."""
+        if emoji:
+            message = f"{message} {emoji}"
+        typer.echo(message)
+
+    def debug_log(self, message: str) -> None:
+        """Write a message to stdout when debug mode is active."""
+        if self.debug:
+            typer.echo(f"🐞 {message}")
+
+    def write_step_summary(self, message: str) -> None:
+        """Append a line to the GitHub Actions step summary."""
+        if not self.step_summary_file:
+            return
+        try:
+            with open(self.step_summary_file, "a", encoding="utf-8") as summary:
+                _ = summary.write(f"{message}\n")
+        except OSError as error:
+            # Writing can fail because a container runs as a different
+            # user than the one that created the summary file.
+            self.debug_log(f"Unable to write to step summary file: {error}")
+
+    def write_github_output(self, key: str, value: str) -> None:
+        """Append a key/value pair to the GitHub Actions output file."""
+        if not self.github_output_file:
+            return
+        try:
+            with open(self.github_output_file, "a", encoding="utf-8") as output:
+                if "\n" in str(value):
+                    _ = output.write(f"{key}<<EOF\n{value}\nEOF\n")
+                else:
+                    _ = output.write(f"{key}={value}\n")
+        except OSError as error:
+            self.debug_log(f"Unable to write to GitHub output file: {error}")
+            self.log(f"Output: {key}={value}")
+
+    @staticmethod
+    def escape_workflow_value(value: str) -> str:
+        """Percent-encode the control characters of a workflow command.
+
+        GitHub Actions treats ``%``, ``\\r``, and ``\\n`` as workflow
+        command control characters, so encoding them prevents command
+        injection through an attacker-supplied value.
+
+        Args:
+            value: The raw string to escape.
+
+        Returns:
+            The escaped string, safe for workflow command output.
+        """
+        value = value.replace("%", "%25")
+        value = value.replace("\r", "%0D")
+        value = value.replace("\n", "%0A")
+        return value
+
+    def emit_workflow_command(self, command: str) -> None:
+        """Write a GitHub Actions workflow command to stdout.
+
+        The runner strips these commands before it displays the log, so
+        writing them through the binary buffer keeps static analysis from
+        mistaking a runner directive for a clear-text log message. The
+        text layer flushes first to stop the two interleaving.
+
+        Args:
+            command: The complete workflow command string.
+        """
+        sys.stdout.flush()
+        sys.stdout.buffer.write(f"{command}\n".encode("utf-8"))
+        sys.stdout.buffer.flush()
+
+    def mask_credentials(self, username: str | None, password: str) -> None:
+        """Register credential values with the GitHub Actions log masker.
+
+        Emits ``::add-mask::`` workflow commands so the runner redacts
+        the values from all later log output. Outside GitHub Actions this
+        is a no-op.
+
+        Args:
+            username: The username to mask, or ``None``.
+            password: The password to mask.
+        """
+        if not os.environ.get("GITHUB_ACTIONS"):
+            return
+        if username:
+            self.emit_workflow_command(
+                f"::add-mask::{self.escape_workflow_value(username)}"
+            )
+        if password:
+            self.emit_workflow_command(
+                f"::add-mask::{self.escape_workflow_value(password)}"
+            )
+
+    def mask_credentials_from_auth_string(self, auth_string: str) -> None:
+        """Mask both halves of a ``user:password`` authentication string.
+
+        Args:
+            auth_string: Credentials in ``user:password`` format.
+        """
+        if ":" in auth_string:
+            username, password = auth_string.split(":", 1)
+        else:
+            username = auth_string
+            password = ""
+        self.mask_credentials(username, password)

--- a/src/http_api_tool/sanitize.py
+++ b/src/http_api_tool/sanitize.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Redaction helpers for values that reach logs or the job summary.
+
+Every function here returns a value that is safe to display. Credential
+extraction lives in ``extract_url_credentials``, whose result must never
+reach a logging call.
+"""
+
+import json
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+SENSITIVE_HEADERS = frozenset(
+    {
+        "authorization",
+        "auth",
+        "x-api-key",
+        "x-auth-token",
+        "x-access-token",
+        "cookie",
+        "set-cookie",
+        "x-csrf-token",
+        "x-session-token",
+        "bearer",
+        "api-key",
+        "access-token",
+    }
+)
+
+SENSITIVE_BODY_PATTERNS = (
+    "password",
+    "secret",
+    "token",
+    "key",
+    "auth",
+    "credential",
+)
+
+
+def sanitize_url_for_logging(url: str) -> str:
+    """Remove credentials from a URL so it is safe to display."""
+    if not url:
+        return url
+
+    try:
+        parsed = urlparse(url)
+        if not (parsed.username or parsed.password):
+            return url
+        sanitized_netloc = parsed.hostname or ""
+        if parsed.port:
+            sanitized_netloc += f":{parsed.port}"
+        return urlunparse(parsed._replace(netloc=sanitized_netloc))
+    except ValueError:
+        return "[URL parsing failed - credentials may be present]"
+
+
+def sanitize_headers_for_logging(headers_json: str) -> str:
+    """Redact the values of headers that commonly carry secrets."""
+    if not headers_json:
+        return headers_json
+
+    try:
+        headers: dict[str, str] = json.loads(headers_json)
+        sanitized = {
+            key: "*** (redacted)" if key.lower() in SENSITIVE_HEADERS else value
+            for key, value in headers.items()
+        }
+        return json.dumps(sanitized)
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return "*** (invalid JSON - potentially sensitive)"
+
+
+def sanitize_request_body_for_logging(body: str, max_length: int = 100) -> str:
+    """Truncate a request body, or withhold it when it looks sensitive."""
+    if not body:
+        return body
+
+    body_lower = body.lower()
+    if any(pattern in body_lower for pattern in SENSITIVE_BODY_PATTERNS):
+        return "*** (request body contains potentially sensitive data)"
+
+    if len(body) > max_length:
+        return body[:max_length] + "... (truncated)"
+    return body
+
+
+def parse_url(url: str) -> dict[str, Any]:
+    """Split a URL into display components, dropping any credentials.
+
+    The ``clean_url`` entry and every other value returned here are safe
+    to log. Use ``extract_url_credentials`` when the credentials
+    themselves are needed.
+    """
+    parsed = urlparse(url)
+
+    port = parsed.port
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+
+    hostname = parsed.hostname or ""
+    # urlparse strips the brackets that delimit an IPv6 literal, so a
+    # round trip through urlunparse must put them back.
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    sanitized_netloc = hostname
+    if parsed.port is not None:
+        sanitized_netloc += f":{parsed.port}"
+    clean_url = urlunparse(parsed._replace(netloc=sanitized_netloc))
+
+    return {
+        "protocol": parsed.scheme,
+        "host": parsed.hostname,
+        "port": port,
+        "path": parsed.path or "/",
+        "query": parsed.query,
+        "fragment": parsed.fragment,
+        "clean_url": clean_url,
+    }
+
+
+def extract_url_credentials(url: str) -> tuple[str | None, str]:
+    """Return the ``(username, password)`` embedded in a URL.
+
+    The return value feeds authentication setup only, and must never be
+    passed to a logging function.
+
+    Args:
+        url: The URL that may carry embedded credentials.
+
+    Returns:
+        A tuple of ``(username, password)``. *username* is ``None`` when
+        the URL carries no credentials; *password* defaults to an empty
+        string.
+    """
+    parsed = urlparse(url)
+    if parsed.username is not None or parsed.password is not None:
+        return (parsed.username, parsed.password or "")
+    return (None, "")

--- a/src/http_api_tool/validation.py
+++ b/src/http_api_tool/validation.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+"""
+Input normalisation and validation.
+
+GitHub Actions delivers every input as a string, so the values arrive
+here untyped and leave as the booleans, integers, and floats the rest of
+the package expects.
+"""
+
+import json
+import os
+import re
+from typing import Any
+
+BOOL_FIELDS = (
+    "verify_ssl",
+    "include_response_body",
+    "follow_redirects",
+    "connection_reuse",
+    "debug",
+    "fail_on_timeout",
+    "show_header_json",
+)
+
+INT_FIELDS = (
+    "initial_sleep_time",
+    "max_delay",
+    "retries",
+    "curl_timeout",
+    "expected_http_code",
+)
+
+TRUTHY_VALUES = frozenset({"true", "1", "yes", "on"})
+
+
+def _coerce_booleans(values: dict[str, Any]) -> None:
+    """Turn the string form of each boolean input into a ``bool``."""
+    for field in BOOL_FIELDS:
+        if field in values and isinstance(values[field], str):
+            values[field] = values[field].lower() in TRUTHY_VALUES
+
+
+def _coerce_integers(values: dict[str, Any]) -> None:
+    """Turn each integer input into a non-negative ``int``."""
+    for field in INT_FIELDS:
+        if field not in values:
+            continue
+        error_msg = f"Error: {field} must be a positive integer ❌"
+        try:
+            parsed = int(values[field])
+        except (ValueError, TypeError):
+            raise ValueError(error_msg) from None
+        if parsed < 0:
+            raise ValueError(error_msg)
+        values[field] = parsed
+
+
+def _coerce_floats(values: dict[str, Any]) -> None:
+    """Turn each floating-point input into a ``float``."""
+    if "max_response_time" not in values:
+        return
+    try:
+        values["max_response_time"] = float(values["max_response_time"])
+    except (ValueError, TypeError):
+        raise ValueError("Error: max_response_time must be a number ❌") from None
+
+
+def _check_patterns(values: dict[str, Any]) -> None:
+    """Reject an unusable regular expression or header JSON document."""
+    if values.get("regex"):
+        try:
+            _ = re.compile(values["regex"])
+        except re.error:
+            raise ValueError(
+                "Error: Invalid regular expression syntax ❌\n"
+                + f"Regex: {values['regex']}"
+            ) from None
+
+    if values.get("request_headers"):
+        try:
+            _ = json.loads(values["request_headers"])
+        except json.JSONDecodeError:
+            raise ValueError("Error: request_headers must be valid JSON ❌") from None
+
+
+def _resolve_url(values: dict[str, Any]) -> None:
+    """Apply the URL fallback, and require a URL under GitHub Actions.
+
+    Typer enforces the URL for CLI use, so only the GitHub Actions entry
+    point needs this guard.
+    """
+    fallback = os.environ.get("HTTP_API_URL")
+    if os.environ.get("GITHUB_ACTIONS") and not values.get("url") and not fallback:
+        raise ValueError("Error: a URL must be provided as input ❌")
+
+    if not values.get("url"):
+        values["url"] = fallback
+
+
+def validate_inputs(**kwargs: Any) -> dict[str, Any]:
+    """Normalise and validate the raw inputs, returning usable values."""
+    _coerce_booleans(kwargs)
+    _resolve_url(kwargs)
+    _coerce_integers(kwargs)
+    _coerce_floats(kwargs)
+    _check_patterns(kwargs)
+    return kwargs

--- a/src/http_api_tool/verifier.py
+++ b/src/http_api_tool/verifier.py
@@ -2,792 +2,270 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 """
-HTTP API testing functionality.
+Retry orchestration for HTTP API testing.
 
-This module contains the main HTTPAPITester class and related utilities.
+``HTTPAPITester`` drives the attempt loop: it validates the inputs, asks
+:mod:`http_api_tool.curl_client` for each request, and reports the
+outcome through an :class:`~http_api_tool.reporting.ActionReporter`.
 """
 
 import base64
-import json
 import os
-import re
 import sys
 import time
-from io import BytesIO
 from typing import Any
-from urllib.parse import urlparse, urlunparse
 
-import pycurl
+from .curl_client import (
+    check_regex_match,
+    create_curl_handle,
+    describe_curl_error,
+    perform_request,
+)
+from .reporting import ActionReporter
+from .sanitize import parse_url, sanitize_url_for_logging
+from .validation import validate_inputs
+
+RESPONSE_CODE_HINTS: dict[int, str] = {
+    401: "Unauthorized; check/supply valid API/service credentials",
+    404: "Not Found; verify the URL or endpoint",
+}
+
+SERVER_ERROR_HINT = "Server Error; the API might be down or overloaded"
+
+
+def _format_target(url_parts: dict[str, Any]) -> str:
+    """Render the credential-free target as ``protocol://host:port``."""
+    return f"{url_parts['protocol']}://{url_parts['host']}:{url_parts['port']}"
+
+
+def _initial_result() -> dict[str, Any]:
+    """Return the output dictionary with its pre-request defaults."""
+    return {
+        "response_http_code": 0,
+        "response_header_json": "{}",
+        "response_header_size": 0,
+        "response_body_size": 0,
+        "total_time": 0,
+        "connect_time": 0,
+        "regex_match": False,
+        "response_body_base64": "",
+        "time_delay": 0,
+        "response_time_exceeded": False,
+    }
 
 
 class HTTPAPITester:
-    """Main class for HTTP API testing functionality."""
-
-    def __init__(self) -> None:
-        self.debug: bool = False
-        self.step_summary_file: str | None = os.environ.get("GITHUB_STEP_SUMMARY")
-        self.github_output_file: str | None = os.environ.get("GITHUB_OUTPUT")
-
-    def log(self, message: str, emoji: str = "") -> None:
-        """Log a message with optional emoji."""
-        if emoji:
-            message = f"{message} {emoji}"
-        print(message)
-
-    def debug_log(self, message: str) -> None:
-        """Log a debug message if debug mode is enabled."""
-        if self.debug:
-            print(f"🐞 {message}")
-
-    def write_step_summary(self, message: str) -> None:
-        """Write to GitHub Actions step summary if available."""
-        if self.step_summary_file:
-            try:
-                with open(self.step_summary_file, "a", encoding="utf-8") as f:
-                    _ = f.write(f"{message}\n")
-            except OSError as e:
-                # Gracefully handle permission errors when running in Docker containers
-                # where the step summary file may not be writable by the current user
-                self.debug_log(f"Unable to write to step summary file: {e}")
-
-    def write_github_output(self, key: str, value: str) -> None:
-        """Write to GitHub Actions output file if available."""
-        if self.github_output_file:
-            try:
-                with open(self.github_output_file, "a", encoding="utf-8") as f:
-                    if "\n" in str(value):
-                        # Multi-line output needs special handling
-                        _ = f.write(f"{key}<<EOF\n{value}\nEOF\n")
-                    else:
-                        _ = f.write(f"{key}={value}\n")
-            except OSError as e:
-                # Gracefully handle permission errors when running in Docker containers
-                # where the output file may not be writable by the current user
-                self.debug_log(f"Unable to write to GitHub output file: {e}")
-                # Still print the output for debugging purposes
-                print(f"Output: {key}={value}")
-
-    def sanitize_url_for_logging(self, url: str) -> str:
-        """Remove credentials from URL for safe logging."""
-        if not url:
-            return url
-
-        try:
-            parsed = urlparse(url)
-            if parsed.username or parsed.password:
-                # Reconstruct URL without credentials
-                sanitized_netloc = parsed.hostname or ""
-                if parsed.port:
-                    sanitized_netloc += f":{parsed.port}"
-
-                sanitized_parsed = parsed._replace(netloc=sanitized_netloc)
-                return urlunparse(sanitized_parsed)
-            return url
-        except Exception:
-            # If URL parsing fails, return a generic placeholder
-            return "[URL parsing failed - credentials may be present]"
-
-    def sanitize_headers_for_logging(self, headers_json: str) -> str:
-        """Remove potentially sensitive headers for safe logging."""
-        if not headers_json:
-            return headers_json
-
-        try:
-            headers: dict[str, str] = json.loads(headers_json)
-            # List of header names that commonly contain sensitive data
-            sensitive_headers = {
-                "authorization",
-                "auth",
-                "x-api-key",
-                "x-auth-token",
-                "x-access-token",
-                "cookie",
-                "set-cookie",
-                "x-csrf-token",
-                "x-session-token",
-                "bearer",
-                "api-key",
-                "access-token",
-            }
-
-            sanitized = {}
-            for key, value in headers.items():
-                if key.lower() in sensitive_headers:
-                    sanitized[key] = "*** (redacted)"
-                else:
-                    sanitized[key] = value
-
-            return json.dumps(sanitized)
-        except (json.JSONDecodeError, TypeError):
-            return "*** (invalid JSON - potentially sensitive)"
-
-    def sanitize_request_body_for_logging(
-        self, body: str, max_length: int = 100
-    ) -> str:
-        """Safely truncate and display request body for logging."""
-        if not body:
-            return body
-
-        # Check if body looks like it might contain sensitive data
-        sensitive_patterns = [
-            "password",
-            "secret",
-            "token",
-            "key",
-            "auth",
-            "credential",
-        ]
-        body_lower = body.lower()
-
-        if any(pattern in body_lower for pattern in sensitive_patterns):
-            return "*** (request body contains potentially sensitive data)"
-
-        # If body seems safe, truncate it
-        if len(body) > max_length:
-            return body[:max_length] + "... (truncated)"
-        return body
-
-    def parse_url(self, url: str) -> dict[str, Any]:
-        """Parse URL and extract safe-to-log components.
-
-        Returns URL components without credentials.  Credential
-        extraction is handled separately by
-        ``_extract_url_credentials`` to prevent sensitive data
-        from flowing into logging functions.
-        """
-        parsed = urlparse(url)
-
-        # Determine default port based on scheme
-        port = parsed.port
-        if port is None:
-            port = 443 if parsed.scheme == "https" else 80
-
-        # Reconstruct URL without credentials
-        hostname = parsed.hostname or ""
-        # Re-add brackets for IPv6 literals (urlparse strips them)
-        if ":" in hostname:
-            hostname = f"[{hostname}]"
-        sanitized_netloc = hostname
-        if parsed.port is not None:
-            sanitized_netloc += f":{parsed.port}"
-        clean_parsed = parsed._replace(netloc=sanitized_netloc)
-        clean_url = urlunparse(clean_parsed)
-
-        return {
-            "protocol": parsed.scheme,
-            "host": parsed.hostname,
-            "port": port,
-            "path": parsed.path or "/",
-            "query": parsed.query,
-            "fragment": parsed.fragment,
-            "clean_url": clean_url,
-        }
-
-    def _extract_url_credentials(self, url: str) -> tuple[str | None, str]:
-        """Extract credentials from a URL string.
-
-        Parses the given URL and returns any embedded username
-        and password.  This method is used only for
-        authentication setup and its return value must never
-        be passed to a logging function.
-
-        Args:
-            url: The URL that may contain embedded credentials.
-
-        Returns:
-            A tuple of ``(username, password)``.  *username* is
-            ``None`` when no credentials are present; *password*
-            defaults to an empty string.
-        """
-        parsed = urlparse(url)
-        if parsed.username is not None or parsed.password is not None:
-            return (parsed.username, parsed.password or "")
-        return (None, "")
-
-    @staticmethod
-    def _escape_workflow_value(value: str) -> str:
-        """Escape a value for use in GitHub Actions workflow commands.
-
-        GitHub Actions workflow commands use ``%``, ``\\r``, and
-        ``\\n`` as control characters.  This method replaces them
-        with their percent-encoded equivalents to prevent
-        command injection.
-
-        Args:
-            value: The raw string to escape.
-
-        Returns:
-            The escaped string safe for workflow command output.
-        """
-        value = value.replace("%", "%25")
-        value = value.replace("\r", "%0D")
-        value = value.replace("\n", "%0A")
-        return value
-
-    def _emit_workflow_command(self, command: str) -> None:
-        """Write a GitHub Actions workflow command to stdout.
-
-        Uses binary buffer I/O to emit runner commands that are
-        processed and stripped by the GitHub Actions runner
-        before log output is displayed.  This avoids static
-        analysis false positives from treating runner commands
-        as clear-text log messages.
-
-        The text layer is flushed first to prevent interleaving
-        with other output written via ``print()``.
-
-        Args:
-            command: The complete workflow command string.
-        """
-        sys.stdout.flush()
-        sys.stdout.buffer.write(f"{command}\n".encode())
-        sys.stdout.buffer.flush()
-
-    def _mask_credentials(self, username: str | None, password: str) -> None:
-        """Mask credential values in GitHub Actions logs.
-
-        Emits ``::add-mask::`` workflow commands so that the
-        runner redacts the given values from all subsequent log
-        output.  Values are escaped to prevent workflow command
-        injection.  Outside GitHub Actions this method is a
-        no-op.
-
-        Args:
-            username: The username to mask, or ``None``.
-            password: The password to mask.
-        """
-        if not os.environ.get("GITHUB_ACTIONS"):
-            return
-        if username:
-            self._emit_workflow_command(
-                f"::add-mask::{self._escape_workflow_value(username)}"
-            )
-        if password:
-            self._emit_workflow_command(
-                f"::add-mask::{self._escape_workflow_value(password)}"
-            )
-
-    def _mask_credentials_from_auth_string(self, auth_string: str) -> None:
-        """Mask both parts of an authentication string.
-
-        Splits *auth_string* on the first ``:`` into a username
-        and password, then delegates to ``_mask_credentials``
-        to register them with the GitHub Actions log masker.
-
-        Args:
-            auth_string: Credentials in ``user:password`` format.
-        """
-        if ":" in auth_string:
-            username, password = auth_string.split(":", 1)
-        else:
-            username = auth_string
-            password = ""
-        self._mask_credentials(username, password)
-
-    def validate_inputs(self, **kwargs: Any) -> dict[str, Any]:
-        """Validate and normalize inputs."""
-        # Convert string boolean inputs to actual booleans for GitHub Actions
-        bool_fields = [
-            "verify_ssl",
-            "include_response_body",
-            "follow_redirects",
-            "connection_reuse",
-            "debug",
-            "fail_on_timeout",
-            "show_header_json",
-        ]
-
-        for field in bool_fields:
-            if field in kwargs and isinstance(kwargs[field], str):
-                kwargs[field] = kwargs[field].lower() in (
-                    "true",
-                    "1",
-                    "yes",
-                    "on",
-                )
-
-        # Validate required URL only if this is called from GitHub Actions context
-        # For CLI usage, the URL validation is handled in the typer command
-        if os.environ.get("GITHUB_ACTIONS"):
-            if not kwargs.get("url") and not os.environ.get("HTTP_API_URL"):
-                raise ValueError("Error: a URL must be provided as input ❌")
-
-        # Use environment variable as fallback
-        if not kwargs.get("url"):
-            kwargs["url"] = os.environ.get("HTTP_API_URL")
-
-        # Validate integer inputs
-        int_fields = [
-            "initial_sleep_time",
-            "max_delay",
-            "retries",
-            "curl_timeout",
-            "expected_http_code",
-        ]
-        for field in int_fields:
-            if field in kwargs:
-                try:
-                    value = int(kwargs[field])
-                    if value < 0:
-                        error_msg = f"Error: {field} must be a positive integer ❌"
-                        raise ValueError(error_msg)
-                    kwargs[field] = value
-                except (ValueError, TypeError):
-                    error_msg = f"Error: {field} must be a positive integer ❌"
-                    raise ValueError(error_msg)
-
-        # Validate float inputs
-        if "max_response_time" in kwargs:
-            try:
-                kwargs["max_response_time"] = float(kwargs["max_response_time"])
-            except (ValueError, TypeError):
-                raise ValueError("Error: max_response_time must be a number ❌")
-
-        # Validate regex if provided
-        if kwargs.get("regex"):
-            try:
-                _ = re.compile(kwargs["regex"])
-            except re.error:
-                raise ValueError(
-                    "Error: Invalid regular expression syntax ❌\n"
-                    + f"Regex: {kwargs['regex']}"
-                )
-
-        # Parse request headers JSON if provided
-        if kwargs.get("request_headers"):
-            try:
-                _ = json.loads(kwargs["request_headers"])
-            except json.JSONDecodeError:
-                raise ValueError("Error: request_headers must be valid JSON ❌")
-
-        return kwargs
-
-    def create_curl_handle(self, **config: Any) -> pycurl.Curl:
-        """Create and configure a pycurl handle."""
-        curl = pycurl.Curl()
-
-        # Basic configuration
-        curl.setopt(pycurl.URL, config["url"])
-        curl.setopt(pycurl.TIMEOUT, config["curl_timeout"])
-        curl.setopt(pycurl.CUSTOMREQUEST, config["http_method"])
-
-        # Security consideration: pycurl's VERBOSE mode will log credentials in clear text
-        # We only enable it if explicitly requested AND warn the user
-        curl.setopt(pycurl.VERBOSE, config["debug"])
-        if config["debug"]:
-            # Check if URL contains credentials
-            username, _ = self._extract_url_credentials(config["url"])
-            if username is not None or config.get("auth_string"):
-                self.log(
-                    "⚠️  Warning: Debug mode enabled with authentication credentials.",
-                    "⚠️",
-                )
-                self.log(
-                    "⚠️  pycurl verbose output may expose credentials in logs.", "⚠️"
-                )
-                self.log("⚠️  Disable debug mode for production use.", "⚠️")
-
-        # SSL/TLS options
-        if not config["verify_ssl"]:
-            curl.setopt(pycurl.SSL_VERIFYPEER, 0)
-            curl.setopt(pycurl.SSL_VERIFYHOST, 0)
-            self.log("Warning: SSL certificate verification disabled", "⚠️")
-        else:
-            # Check if a custom CA bundle is provided
-            ca_bundle_path = config.get("ca_bundle_path")
-            if ca_bundle_path:
-                if os.path.isfile(ca_bundle_path):
-                    curl.setopt(pycurl.CAINFO, ca_bundle_path)
-                    self.debug_log(f"Using custom CA bundle: {ca_bundle_path}")
-                else:
-                    self.log(
-                        f"Warning: CA bundle file not found: {ca_bundle_path}", "⚠️"
-                    )
-
-        # Connection options
-        if not config["connection_reuse"]:
-            curl.setopt(pycurl.FRESH_CONNECT, 1)
-            curl.setopt(pycurl.FORBID_REUSE, 1)
-
-        # Redirect handling
-        if config["follow_redirects"]:
-            curl.setopt(pycurl.FOLLOWLOCATION, 1)
-        else:
-            curl.setopt(pycurl.MAXREDIRS, 0)
-
-        # Authentication
-        auth_string = config.get("auth_string")
-        if not auth_string:
-            # Try to extract from URL
-            username, password = self._extract_url_credentials(config["url"])
-            if username is not None:
-                auth_string = f"{username}:{password}"
-
-        if auth_string:
-            # Mask credentials in GitHub Actions logs
-            self._mask_credentials_from_auth_string(auth_string)
-            self.log("Authentication credentials provided", "💬")
-            curl.setopt(pycurl.USERPWD, auth_string)
-
-        # Headers
-        headers = []
-
-        # Content-Type for request body
-        if config.get("request_body"):
-            headers.append(f"Content-Type: {config['content_type']}")
-
-        # Custom headers from JSON
-        if config.get("request_headers"):
-            try:
-                custom_headers = json.loads(config["request_headers"])
-                for key, value in custom_headers.items():
-                    headers.append(f"{key}: {value}")
-                # Use sanitized headers for debug logging
-                sanitized_headers_json = self.sanitize_headers_for_logging(
-                    config["request_headers"]
-                )
-                self.debug_log(f"Added custom headers: {sanitized_headers_json}")
-            except json.JSONDecodeError:
-                raise ValueError("Error: Invalid JSON in request_headers ❌")
-
-        if headers:
-            curl.setopt(pycurl.HTTPHEADER, headers)
-
-        # Request body
-        if config.get("request_body"):
-            body_data = config["request_body"].encode("utf-8")
-            curl.setopt(pycurl.POSTFIELDS, body_data)
-            curl.setopt(pycurl.POSTFIELDSIZE, len(body_data))
-
-        # Response handling
-        if (
-            not config.get("regex")
-            and not config.get("include_response_body", True)
-            and not config["debug"]
-        ):
-            curl.setopt(pycurl.NOBODY, 1)  # HEAD request
-
-        return curl
-
-    def perform_request(self, curl: pycurl.Curl) -> dict[str, Any]:
-        """Perform HTTP request and return response data."""
-        # Prepare buffers
-        response_buffer = BytesIO()
-        header_buffer = BytesIO()
-
-        curl.setopt(pycurl.WRITEDATA, response_buffer)
-        curl.setopt(pycurl.HEADERFUNCTION, header_buffer.write)
-
-        try:
-            curl.perform()
-
-            # Get response metrics
-            response_code = curl.getinfo(pycurl.RESPONSE_CODE)
-            total_time = curl.getinfo(pycurl.TOTAL_TIME)
-            connect_time = curl.getinfo(pycurl.CONNECT_TIME)
-            download_size = curl.getinfo(pycurl.SIZE_DOWNLOAD)
-            header_size = curl.getinfo(pycurl.HEADER_SIZE)
-
-            # Get response content
-            response_body = response_buffer.getvalue()
-            response_headers = header_buffer.getvalue().decode("utf-8", errors="ignore")
-
-            # Parse headers into JSON format
-            header_json = self._parse_headers_to_json(response_headers)
-
-            return {
-                "success": True,
-                "http_code": int(response_code),
-                "total_time": total_time,
-                "connect_time": connect_time,
-                "body_size": int(download_size),
-                "header_size": int(header_size),
-                "response_body": response_body,
-                "response_headers": response_headers,
-                "header_json": header_json,
-                "curl_error": None,
-            }
-
-        except pycurl.error as e:
-            error_code = e.args[0] if len(e.args) > 0 else 0
-            error_msg = e.args[1] if len(e.args) > 1 else str(e)
-            return {
-                "success": False,
-                "http_code": 0,
-                "total_time": 0,
-                "connect_time": 0,
-                "body_size": 0,
-                "header_size": 0,
-                "response_body": b"",
-                "response_headers": "",
-                "header_json": "{}",
-                "curl_error": (error_code, error_msg),
-            }
-
-    def _parse_headers_to_json(self, headers_text: str) -> str:
-        """Parse HTTP headers text into JSON format."""
-        if not headers_text.strip():
-            return "{}"
-
-        headers_dict = {}
-        lines = headers_text.strip().split("\n")
-
-        for line in lines:
-            line = line.strip()
-            if not line or line.startswith("HTTP/"):
-                continue
-
-            if ":" in line:
-                key, value = line.split(":", 1)
-                headers_dict[key.strip()] = value.strip()
-
-        try:
-            return json.dumps(headers_dict, separators=(",", ":"))
-        except Exception:
-            return "{}"
-
-    def check_regex_match(self, response_body: bytes, regex_pattern: str) -> bool:
-        """Check if response body matches the given regex pattern."""
-        if not regex_pattern:
-            return True
-
-        try:
-            # Decode response body to string for regex matching
-            body_text = response_body.decode("utf-8", errors="ignore")
-            return bool(re.search(regex_pattern, body_text))
-        except Exception:
+    """Test an HTTP API endpoint, retrying until it answers or gives up."""
+
+    def __init__(self, reporter: ActionReporter | None = None) -> None:
+        self.reporter: ActionReporter = reporter or ActionReporter()
+
+    def handle_curl_error(self, error_code: int) -> bool:
+        """Report a cURL failure and say whether retrying is worthwhile."""
+        self.reporter.log(f"cURL error code: {error_code}")
+        message, fatal = describe_curl_error(error_code)
+        self.reporter.log(message, "❌")
+        if fatal:
+            self.reporter.write_step_summary(f"{message} ❌")
             return False
+        return True
 
-    def handle_curl_error(self, error_code: int, _error_msg: str) -> bool:
-        """Handle cURL errors and return whether to continue retrying."""
-        self.log(f"cURL error code: {error_code}")
+    def _describe_target(
+        self, config: dict[str, Any], url_parts: dict[str, Any]
+    ) -> None:
+        """Log the target of the run and open the step summary."""
+        if os.environ.get("GITHUB_ACTIONS"):
+            self.reporter.log(f"🎯 Starting test: {config['service_name']}")
+            self.reporter.log(
+                f"🌐 Target URL: {sanitize_url_for_logging(config['url'])}"
+            )
 
-        # Define error messages and whether they should cause immediate exit
-        error_handlers = {
-            1: ("Error: Unsupported protocol", False),
-            3: ("Error: URL malformed", False),
-            5: ("Error: Couldn't resolve proxy", False),
-            6: ("Error: Couldn't resolve host", False),
-            7: ("Error: Failed to connect to host", False),
-            28: ("Error: Request timeout", False),
-            35: ("Error: SSL connect error", True),  # Immediate exit
-            51: (
-                "Error: The peer's SSL certificate is not OK",
-                True,
-            ),  # Immediate exit
-            52: ("Error: Nothing was returned from the server", False),
-            60: ("Error: SSL self-signed certificate", True),  # Immediate exit
-        }
+        self.reporter.debug_log("URL Debug Info:")
+        self.reporter.debug_log(
+            f"  Original URL: '{sanitize_url_for_logging(config['url'])}'"
+        )
+        self.reporter.debug_log(f"  Protocol: '{url_parts['protocol']}'")
+        self.reporter.debug_log(f"  Host: '{url_parts['host']}'")
+        self.reporter.debug_log(f"  Port: '{url_parts['port']}'")
+        self.reporter.debug_log(f"  Path: '{url_parts['path']}'")
 
-        if error_code in error_handlers:
-            error_msg_formatted, should_exit = error_handlers[error_code]
-            self.log(error_msg_formatted, "❌")
-            if should_exit:
-                self.write_step_summary(f"{error_msg_formatted} ❌")
-                return False  # Stop retrying
+        self.reporter.write_step_summary(f"# {config['service_name']}")
+        self.reporter.write_step_summary("### Check API/Service Availability 🌍")
+
+    def _run_attempt(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Perform one request, releasing the handle whatever happens."""
+        curl = create_curl_handle(self.reporter, **config)
+        try:
+            return perform_request(curl)
+        finally:
+            curl.close()
+
+    def _record_response(
+        self, result: dict[str, Any], response: dict[str, Any], time_delay: int
+    ) -> None:
+        """Copy the response metrics of one attempt into the outputs."""
+        result.update(
+            {
+                "response_http_code": response["http_code"],
+                "response_header_json": response["header_json"],
+                "response_header_size": response["header_size"],
+                "response_body_size": response["body_size"],
+                "total_time": response["total_time"],
+                "connect_time": response["connect_time"],
+                "time_delay": time_delay,
+            }
+        )
+        self.reporter.debug_log(f"Response Code: {response['http_code']}")
+        self.reporter.debug_log(f"Header Size: {response['header_size']} bytes")
+        self.reporter.debug_log(f"Body Size: {response['body_size']} bytes")
+
+    def _log_success(
+        self,
+        response: dict[str, Any],
+        url_parts: dict[str, Any],
+        counter: int,
+        time_delay: int,
+    ) -> None:
+        """Announce that the service answered with the expected code."""
+        target = _format_target(url_parts)
+        self.reporter.log(target, "✅")
+        self.reporter.write_step_summary(f"{target} ✅")
+        self.reporter.log(f"Returned status code: {response['http_code']}")
+        if counter > 1:
+            self.reporter.log(
+                f"Time taken for service availability: {time_delay}", "💬"
+            )
+
+    def _check_response_time(
+        self, result: dict[str, Any], response: dict[str, Any], config: dict[str, Any]
+    ) -> None:
+        """Compare the response time against the configured ceiling."""
+        max_time = config["max_response_time"]
+        total_time = response["total_time"]
+        if max_time <= 0 or not total_time:
+            return
+
+        if total_time <= max_time:
+            self.reporter.log(
+                f"Response time within acceptable limit "
+                f"({total_time} <= {max_time} seconds)",
+                "✅",
+            )
+            self.reporter.write_step_summary(f"Response Time: {total_time} seconds")
+            return
+
+        self.reporter.log(
+            f"Warning: Response time exceeded maximum "
+            f"({total_time} > {max_time} seconds)",
+            "⚠️",
+        )
+        result["response_time_exceeded"] = True
+        self.reporter.write_step_summary(
+            f"Response Time: {total_time} seconds (exceeded limit of {max_time})"
+        )
+        if config["fail_on_timeout"]:
+            self.reporter.log(
+                "Error: Response time exceeded maximum allowed time", "❌"
+            )
+            self.reporter.write_step_summary(
+                "Error: Response time exceeded maximum allowed time ❌"
+            )
+            sys.exit(1)
+
+    def _check_regex(
+        self, result: dict[str, Any], response: dict[str, Any], config: dict[str, Any]
+    ) -> None:
+        """Match the response body against the configured pattern."""
+        pattern = config.get("regex")
+        if not pattern:
+            return
+
+        self.reporter.log("Regular expression provided; validating response/reply")
+        body = response["response_body"]
+        if not body:
+            self.reporter.log(
+                "Error: regex validation requested, but response empty", "❌"
+            )
+            sys.exit(1)
+
+        matched = check_regex_match(body, pattern)
+        result["regex_match"] = matched
+        if matched:
+            self.reporter.log("RegEx matched server reply/body", "✅")
+            self.reporter.write_step_summary("RegEx matched server reply/body ✅")
         else:
-            self.log(f"Error: cURL encountered an error (code {error_code})", "❌")
+            self.reporter.log("Warning: RegEx NOT matched server reply/body", "⚠️")
+            self.reporter.write_step_summary(
+                "Warning: RegEx NOT matched server reply/body ⚠️"
+            )
 
-        return True  # Continue retrying for non-fatal errors
+    def _report_exhausted(
+        self, result: dict[str, Any], url_parts: dict[str, Any], time_delay: int
+    ) -> None:
+        """Report that every attempt failed, and hint at the likely cause."""
+        target = _format_target(url_parts)
+        self.reporter.write_step_summary(target)
+        self.reporter.log(target)
+        failure = f"Error: service marked failed at {time_delay} seconds"
+        self.reporter.log(failure, "❌")
+        self.reporter.write_step_summary(f"{failure} ❌")
+
+        response_code = result["response_http_code"]
+        if not isinstance(response_code, int):
+            return
+        hint = RESPONSE_CODE_HINTS.get(response_code)
+        if hint is None and response_code >= 500:
+            hint = SERVER_ERROR_HINT
+        if hint:
+            self.reporter.log(hint, "⚠️")
 
     def test_api(self, **config: Any) -> dict[str, Any]:
-        """Main testing function with retry logic."""
-        # Validate inputs
-        config = self.validate_inputs(**config)
-        self.debug = config["debug"]
+        """Test the configured endpoint, retrying until it answers.
 
-        # Parse URL for display purposes
-        url_parts = self.parse_url(config["url"])
-        protocol = url_parts["protocol"]
-        host = url_parts["host"]
-        port = url_parts["port"]
+        Returns the collected outputs once the service returns the
+        expected status code. Exits the process when the retries run out
+        or an unrecoverable error occurs.
+        """
+        config = validate_inputs(**config)
+        self.reporter.debug = config["debug"]
 
-        # Show what we're about to verify (for GitHub Actions context)
-        if os.environ.get("GITHUB_ACTIONS"):
-            self.log(f"🎯 Starting test: {config['service_name']}")
-            self.log(f"🌐 Target URL: {self.sanitize_url_for_logging(config['url'])}")
+        url_parts = parse_url(config["url"])
+        self._describe_target(config, url_parts)
 
-        self.debug_log("URL Debug Info:")
-        self.debug_log(
-            f"  Original URL: '{self.sanitize_url_for_logging(config['url'])}'"
-        )
-        self.debug_log(f"  Protocol: '{protocol}'")
-        self.debug_log(f"  Host: '{host}'")
-        self.debug_log(f"  Port: '{port}'")
-        self.debug_log(f"  Path: '{url_parts['path']}'")
-
-        # Write initial step summary
-        self.write_step_summary(f"# {config['service_name']}")
-        self.write_step_summary("### Check API/Service Availability 🌍")
-
-        # Initialize counters
+        result = _initial_result()
         counter = 0
         time_delay = 0
         sleep_time = config["initial_sleep_time"]
 
-        # Initialize default outputs
-        result = {
-            "response_http_code": 0,
-            "response_header_json": "{}",
-            "response_header_size": 0,
-            "response_body_size": 0,
-            "total_time": 0,
-            "connect_time": 0,
-            "regex_match": False,
-            "response_body_base64": "",
-            "time_delay": 0,
-            "response_time_exceeded": False,
-        }
-
-        # Main retry loop
         while True:
             counter += 1
+            self.reporter.debug_log(f"Attempt: {counter} / {config['retries']}")
+            self.reporter.debug_log(f"Delay/Wait Interval: {sleep_time} seconds")
+            self.reporter.debug_log(f"Delay/Wait Current Value: {time_delay} seconds")
 
-            self.debug_log(f"Attempt: {counter} / {config['retries']}")
-            self.debug_log(f"Delay/Wait Interval: {sleep_time} seconds")
-            self.debug_log(f"Delay/Wait Current Value: {time_delay} seconds")
+            response = self._run_attempt(config)
+            self._record_response(result, response, time_delay)
+            if config["include_response_body"] and response["response_body"]:
+                result["response_body_base64"] = base64.b64encode(
+                    response["response_body"]
+                ).decode("ascii")
 
-            # Create and configure curl handle
-            curl = self.create_curl_handle(**config)
+            if not response["success"]:
+                error_code, _ = response["curl_error"]
+                if not self.handle_curl_error(error_code):
+                    sys.exit(1)
+            elif response["http_code"] == config["expected_http_code"]:
+                self._log_success(response, url_parts, counter, time_delay)
+                self._check_response_time(result, response, config)
+                self._check_regex(result, response, config)
+                return result
 
-            try:
-                # Perform the request
-                response = self.perform_request(curl)
-
-                # Update result with response data
-                result.update(
-                    {
-                        "response_http_code": response["http_code"],
-                        "response_header_json": response["header_json"],
-                        "response_header_size": response["header_size"],
-                        "response_body_size": response["body_size"],
-                        "total_time": response["total_time"],
-                        "connect_time": response["connect_time"],
-                        "time_delay": time_delay,
-                    }
-                )
-
-                # Handle response body if requested
-                if config["include_response_body"] and response["response_body"]:
-                    result["response_body_base64"] = base64.b64encode(
-                        response["response_body"]
-                    ).decode("ascii")
-
-                self.debug_log(f"Response Code: {response['http_code']}")
-                self.debug_log(f"Header Size: {response['header_size']} bytes")
-                self.debug_log(f"Body Size: {response['body_size']} bytes")
-
-                # Check if request was successful
-                if not response["success"]:
-                    error_code, error_msg = response["curl_error"]
-                    if not self.handle_curl_error(error_code, error_msg):
-                        # Fatal error - exit immediately
-                        sys.exit(1)
-                else:
-                    # Request succeeded - check response code
-                    if response["http_code"] == config["expected_http_code"]:
-                        self.log(f"{protocol}://{host}:{port}", "✅")
-                        self.write_step_summary(f"{protocol}://{host}:{port} ✅")
-                        self.log(f"Returned status code: {response['http_code']}")
-
-                        if counter > 1:
-                            self.log(
-                                f"Time taken for service availability: {time_delay}",
-                                "💬",
-                            )
-
-                        # Validate response time if specified
-                        if config["max_response_time"] > 0 and response["total_time"]:
-                            if response["total_time"] > config["max_response_time"]:
-                                self.log(
-                                    f"Warning: Response time exceeded maximum ({response['total_time']} > {config['max_response_time']} seconds)",
-                                    "⚠️",
-                                )
-                                result["response_time_exceeded"] = True
-                                self.write_step_summary(
-                                    f"Response Time: {response['total_time']} seconds (exceeded limit of {config['max_response_time']})"
-                                )
-
-                                if config["fail_on_timeout"]:
-                                    self.log(
-                                        "Error: Response time exceeded maximum allowed time",
-                                        "❌",
-                                    )
-                                    self.write_step_summary(
-                                        "Error: Response time exceeded maximum allowed time ❌"
-                                    )
-                                    sys.exit(1)
-                            else:
-                                self.log(
-                                    f"Response time within acceptable limit ({response['total_time']} <= {config['max_response_time']} seconds)",
-                                    "✅",
-                                )
-                                self.write_step_summary(
-                                    f"Response Time: {response['total_time']} seconds"
-                                )
-
-                        # Check regex if provided
-                        if config.get("regex"):
-                            self.log(
-                                "Regular expression provided; validating response/reply"
-                            )
-                            if not response["response_body"]:
-                                self.log(
-                                    "Error: regex validation requested, but response empty",
-                                    "❌",
-                                )
-                                sys.exit(1)
-
-                            if self.check_regex_match(
-                                response["response_body"], config["regex"]
-                            ):
-                                self.log("RegEx matched server reply/body", "✅")
-                                self.write_step_summary(
-                                    "RegEx matched server reply/body ✅"
-                                )
-                                result["regex_match"] = True
-                            else:
-                                self.log(
-                                    "Warning: RegEx NOT matched server reply/body", "⚠️"
-                                )
-                                self.write_step_summary(
-                                    "Warning: RegEx NOT matched server reply/body ⚠️"
-                                )
-                                result["regex_match"] = False
-
-                        # Success!
-                        return result
-
-            finally:
-                curl.close()
-
-            # Check if we've exhausted all retries
             if counter >= config["retries"]:
-                self.write_step_summary(f"{protocol}://{host}:{port}")
-                self.log(f"{protocol}://{host}:{port}")
-                self.log(f"Error: service marked failed at {time_delay} seconds", "❌")
-                self.write_step_summary(
-                    f"Error: service marked failed at {time_delay} seconds ❌"
-                )
-
-                # Provide feedback on common response codes
-                response_code = result["response_http_code"]
-                if isinstance(response_code, int) and response_code == 401:
-                    self.log(
-                        "Unauthorized; check/supply valid API/service credentials", "⚠️"
-                    )
-                elif isinstance(response_code, int) and response_code == 404:
-                    self.log("Not Found; verify the URL or endpoint", "⚠️")
-                elif isinstance(response_code, int) and response_code >= 500:
-                    self.log("Server Error; the API might be down or overloaded", "⚠️")
-
+                self._report_exhausted(result, url_parts, time_delay)
                 sys.exit(1)
 
-            # Wait before next retry
-            self.log(f"Waiting for {sleep_time} seconds before retrying...")
+            self.reporter.log(f"Waiting for {sleep_time} seconds before retrying...")
             time.sleep(sleep_time)
             time_delay += sleep_time
-
-            # Exponential backoff with cap
             sleep_time = min(sleep_time * (2 ** (counter - 1)), config["max_delay"])
-            self.log(f"Sleep/wait time for next attempt: {sleep_time} seconds")
+            self.reporter.log(f"Sleep/wait time for next attempt: {sleep_time} seconds")

--- a/tests/test_http_api_tool.py
+++ b/tests/test_http_api_tool.py
@@ -37,7 +37,15 @@ from unittest.mock import Mock, patch
 import pycurl
 import pytest
 
-# Import the module to test
+from http_api_tool.curl_client import (
+    check_regex_match,
+    create_curl_handle,
+    parse_headers_to_json,
+    perform_request,
+)
+from http_api_tool.reporting import ActionReporter
+from http_api_tool.sanitize import extract_url_credentials, parse_url
+from http_api_tool.validation import validate_inputs
 from http_api_tool.verifier import HTTPAPITester
 
 
@@ -50,12 +58,14 @@ class TestHTTPAPITester:
     """
 
     verifier: HTTPAPITester  # pyright: ignore[reportUninitializedInstanceVariable]
+    reporter: ActionReporter  # pyright: ignore[reportUninitializedInstanceVariable]
     temp_summary: Any = None
     temp_output: Any = None
 
     def setup_method(self) -> None:
         """Set up test fixtures."""
-        self.verifier = HTTPAPITester()
+        self.reporter = ActionReporter()
+        self.verifier = HTTPAPITester(self.reporter)
         # Create temporary files for GitHub Actions simulation
         self.temp_summary = tempfile.NamedTemporaryFile(mode="w+", delete=False)
         self.temp_output = tempfile.NamedTemporaryFile(mode="w+", delete=False)
@@ -64,8 +74,8 @@ class TestHTTPAPITester:
         os.environ["GITHUB_STEP_SUMMARY"] = self.temp_summary.name
         os.environ["GITHUB_OUTPUT"] = self.temp_output.name
 
-        self.verifier.step_summary_file = self.temp_summary.name
-        self.verifier.github_output_file = self.temp_output.name
+        self.reporter.step_summary_file = self.temp_summary.name
+        self.reporter.github_output_file = self.temp_output.name
 
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
@@ -84,7 +94,7 @@ class TestHTTPAPITester:
     def test_parse_url_basic(self) -> None:
         """Test basic URL parsing."""
         url = "https://example.com:8080/api/v1"
-        result = self.verifier.parse_url(url)
+        result = parse_url(url)
 
         assert result["protocol"] == "https"
         assert result["host"] == "example.com"
@@ -94,7 +104,7 @@ class TestHTTPAPITester:
     def test_parse_url_with_credentials(self) -> None:
         """Test URL parsing with embedded credentials."""
         url = "http://user:pass@example.com/api"
-        result = self.verifier.parse_url(url)
+        result = parse_url(url)
 
         assert result["protocol"] == "http"
         assert result["host"] == "example.com"
@@ -107,89 +117,81 @@ class TestHTTPAPITester:
     def test_parse_url_default_ports(self) -> None:
         """Test URL parsing with default ports."""
         # HTTP default port
-        result = self.verifier.parse_url("http://example.com")
+        result = parse_url("http://example.com")
         assert result["port"] == 80
 
         # HTTPS default port
-        result = self.verifier.parse_url("https://example.com")
+        result = parse_url("https://example.com")
         assert result["port"] == 443
 
     def test_extract_url_credentials_basic(self) -> None:
         """Test credential extraction from URL without credentials."""
-        username, password = self.verifier._extract_url_credentials(
-            "https://example.com/api"
-        )
+        username, password = extract_url_credentials("https://example.com/api")
         assert username is None
         assert password == ""
 
     def test_extract_url_credentials_with_creds(self) -> None:
         """Test credential extraction from URL with username and password."""
-        username, password = self.verifier._extract_url_credentials(
-            "http://user:pass@example.com/api"
-        )
+        username, password = extract_url_credentials("http://user:pass@example.com/api")
         assert username == "user"
         assert password == "pass"
 
     def test_extract_url_credentials_username_only(self) -> None:
         """Test credential extraction from URL with username only."""
-        username, password = self.verifier._extract_url_credentials(
-            "http://user@example.com/api"
-        )
+        username, password = extract_url_credentials("http://user@example.com/api")
         assert username == "user"
         assert password == ""
 
     def test_extract_url_credentials_empty_username(self) -> None:
         """Test credential extraction from URL with empty username."""
-        username, password = self.verifier._extract_url_credentials(
-            "http://:pass@example.com/api"
-        )
+        username, password = extract_url_credentials("http://:pass@example.com/api")
         assert username == ""
         assert password == "pass"
 
-    @patch.object(HTTPAPITester, "_emit_workflow_command")
+    @patch.object(ActionReporter, "emit_workflow_command")
     def test_mask_credentials_github_actions(self, mock_emit: Mock) -> None:
         """Test that credentials are masked when running in GitHub Actions."""
         with patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}):
-            self.verifier._mask_credentials("user", "pass")
+            self.reporter.mask_credentials("user", "pass")
             mock_emit.assert_any_call("::add-mask::user")
             mock_emit.assert_any_call("::add-mask::pass")
 
-    @patch.object(HTTPAPITester, "_emit_workflow_command")
+    @patch.object(ActionReporter, "emit_workflow_command")
     def test_mask_credentials_not_github_actions(self, mock_emit: Mock) -> None:
         """Test that credentials are not masked outside GitHub Actions."""
         env = os.environ.copy()
         _ = env.pop("GITHUB_ACTIONS", None)
         with patch.dict(os.environ, env, clear=True):
-            self.verifier._mask_credentials("user", "pass")
+            self.reporter.mask_credentials("user", "pass")
             mock_emit.assert_not_called()
 
-    @patch.object(HTTPAPITester, "_emit_workflow_command")
+    @patch.object(ActionReporter, "emit_workflow_command")
     def test_mask_credentials_escapes_special_chars(self, mock_emit: Mock) -> None:
         """Test that special characters are escaped in mask commands."""
         with patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}):
-            self.verifier._mask_credentials("user%name", "pa\nss\r")
+            self.reporter.mask_credentials("user%name", "pa\nss\r")
             mock_emit.assert_any_call("::add-mask::user%25name")
             mock_emit.assert_any_call("::add-mask::pa%0Ass%0D")
 
     def test_escape_workflow_value(self) -> None:
         """Test escaping of GitHub Actions workflow command values."""
-        assert self.verifier._escape_workflow_value("plain") == "plain"
-        assert self.verifier._escape_workflow_value("a%b") == "a%25b"
-        assert self.verifier._escape_workflow_value("a\nb") == "a%0Ab"
-        assert self.verifier._escape_workflow_value("a\rb") == "a%0Db"
-        assert self.verifier._escape_workflow_value("a%\r\n") == "a%25%0D%0A"
+        assert self.reporter.escape_workflow_value("plain") == "plain"
+        assert self.reporter.escape_workflow_value("a%b") == "a%25b"
+        assert self.reporter.escape_workflow_value("a\nb") == "a%0Ab"
+        assert self.reporter.escape_workflow_value("a\rb") == "a%0Db"
+        assert self.reporter.escape_workflow_value("a%\r\n") == "a%25%0D%0A"
 
     def test_emit_workflow_command(
         self, capsysbinary: pytest.CaptureFixture[bytes]
     ) -> None:
         """Test that workflow commands are written as binary to stdout."""
-        self.verifier._emit_workflow_command("::add-mask::secret")
+        self.reporter.emit_workflow_command("::add-mask::secret")
         captured = capsysbinary.readouterr()
         assert captured.out == b"::add-mask::secret\n"
 
     def test_parse_url_ipv6(self) -> None:
         """Test URL parsing preserves IPv6 bracket notation."""
-        result = self.verifier.parse_url("http://[::1]:8080/api")
+        result = parse_url("http://[::1]:8080/api")
         assert result["host"] == "::1"
         assert result["port"] == 8080
         assert "[::1]:8080" in result["clean_url"]
@@ -205,7 +207,7 @@ class TestHTTPAPITester:
             "debug": "false",
         }
 
-        result = self.verifier.validate_inputs(**inputs)
+        result = validate_inputs(**inputs)
 
         assert result["url"] == "https://example.com"
         assert result["retries"] == 3
@@ -219,7 +221,7 @@ class TestHTTPAPITester:
         os.environ["HTTP_API_URL"] = "https://env-example.com"
 
         inputs = {"retries": "3"}
-        result = self.verifier.validate_inputs(**inputs)
+        result = validate_inputs(**inputs)
 
         assert result["url"] == "https://env-example.com"
 
@@ -230,7 +232,7 @@ class TestHTTPAPITester:
         # Mock GitHub Actions environment
         with patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}):
             with pytest.raises(ValueError, match="Error: a URL must be provided"):
-                _ = self.verifier.validate_inputs(**inputs)
+                _ = validate_inputs(**inputs)
 
     def test_validate_inputs_missing_url_cli(self) -> None:
         """Test that missing URL in CLI context does not raise error in validate_inputs."""
@@ -239,7 +241,7 @@ class TestHTTPAPITester:
         # Ensure we're not in GitHub Actions context
         with patch.dict(os.environ, {}, clear=True):
             # This should not raise an error since URL validation is skipped in CLI mode
-            result = self.verifier.validate_inputs(**inputs)
+            result = validate_inputs(**inputs)
             assert result["retries"] == 3
 
     def test_validate_inputs_invalid_integer(self) -> None:
@@ -247,14 +249,14 @@ class TestHTTPAPITester:
         inputs = {"url": "https://example.com", "retries": "invalid"}
 
         with pytest.raises(ValueError, match="retries must be a positive integer"):
-            _ = self.verifier.validate_inputs(**inputs)
+            _ = validate_inputs(**inputs)
 
     def test_validate_inputs_negative_integer(self) -> None:
         """Test validation error for negative integer inputs."""
         inputs = {"url": "https://example.com", "retries": "-1"}
 
         with pytest.raises(ValueError, match="retries must be a positive integer"):
-            _ = self.verifier.validate_inputs(**inputs)
+            _ = validate_inputs(**inputs)
 
     def test_validate_inputs_invalid_regex(self) -> None:
         """Test validation error for invalid regex."""
@@ -264,14 +266,14 @@ class TestHTTPAPITester:
         }
 
         with pytest.raises(ValueError, match="Invalid regular expression syntax"):
-            _ = self.verifier.validate_inputs(**inputs)
+            _ = validate_inputs(**inputs)
 
     def test_validate_inputs_invalid_json_headers(self) -> None:
         """Test validation error for invalid JSON headers."""
         inputs = {"url": "https://example.com", "request_headers": "{invalid json}"}
 
         with pytest.raises(ValueError, match="request_headers must be valid JSON"):
-            _ = self.verifier.validate_inputs(**inputs)
+            _ = validate_inputs(**inputs)
 
     def test_validate_inputs_valid_json_headers(self) -> None:
         """Test validation with valid JSON headers."""
@@ -280,7 +282,7 @@ class TestHTTPAPITester:
             "request_headers": '{"Content-Type": "application/json", "X-API-Key": "test"}',
         }
 
-        result = self.verifier.validate_inputs(**inputs)
+        result = validate_inputs(**inputs)
         assert (
             result["request_headers"]
             == '{"Content-Type": "application/json", "X-API-Key": "test"}'
@@ -296,7 +298,7 @@ X-Custom-Header: test-value
 
 """
 
-        result = self.verifier._parse_headers_to_json(headers_text)
+        result = parse_headers_to_json(headers_text)
         parsed = json.loads(result)
 
         assert parsed["Content-Type"] == "application/json"
@@ -306,7 +308,7 @@ X-Custom-Header: test-value
 
     def test_parse_headers_to_json_empty(self) -> None:
         """Test headers parsing with empty input."""
-        result = self.verifier._parse_headers_to_json("")
+        result = parse_headers_to_json("")
         assert result == "{}"
 
     def test_check_regex_match_success(self) -> None:
@@ -314,7 +316,7 @@ X-Custom-Header: test-value
         response_body = b'{"status": "success", "message": "API is working"}'
         regex_pattern = r'"status":\s*"success"'
 
-        result = self.verifier.check_regex_match(response_body, regex_pattern)
+        result = check_regex_match(response_body, regex_pattern)
         assert result is True
 
     def test_check_regex_match_failure(self) -> None:
@@ -322,37 +324,37 @@ X-Custom-Header: test-value
         response_body = b'{"status": "error", "message": "API is down"}'
         regex_pattern = r'"status":\s*"success"'
 
-        result = self.verifier.check_regex_match(response_body, regex_pattern)
+        result = check_regex_match(response_body, regex_pattern)
         assert result is False
 
     def test_check_regex_match_no_pattern(self) -> None:
         """Test regex matching with no pattern (should return True)."""
         response_body = b'{"status": "success"}'
 
-        result = self.verifier.check_regex_match(response_body, "")
+        result = check_regex_match(response_body, "")
         assert result is True
 
     def test_handle_curl_error_non_fatal(self) -> None:
         """Test handling of non-fatal cURL errors."""
         # Test connection timeout (should continue retrying)
-        result = self.verifier.handle_curl_error(7, "Failed to connect")
+        result = self.verifier.handle_curl_error(7)
         assert result is True
 
     def test_handle_curl_error_fatal(self) -> None:
         """Test handling of fatal cURL errors."""
         # Test SSL error (should stop retrying)
-        result = self.verifier.handle_curl_error(35, "SSL connect error")
+        result = self.verifier.handle_curl_error(35)
         assert result is False
 
     def test_handle_curl_error_unknown(self) -> None:
         """Test handling of unknown cURL errors."""
         # Test unknown error code (should continue retrying)
-        result = self.verifier.handle_curl_error(999, "Unknown error")
+        result = self.verifier.handle_curl_error(999)
         assert result is True
 
     def test_write_step_summary(self) -> None:
         """Test writing to GitHub Actions step summary."""
-        self.verifier.write_step_summary("Test summary message")
+        self.reporter.write_step_summary("Test summary message")
 
         with open(self.temp_summary.name, "r") as f:
             content = f.read()
@@ -361,7 +363,7 @@ X-Custom-Header: test-value
 
     def test_write_github_output_single_line(self) -> None:
         """Test writing single-line output to GitHub Actions."""
-        self.verifier.write_github_output("test_key", "test_value")
+        self.reporter.write_github_output("test_key", "test_value")
 
         with open(self.temp_output.name, "r") as f:
             content = f.read()
@@ -371,14 +373,14 @@ X-Custom-Header: test-value
     def test_write_github_output_multi_line(self) -> None:
         """Test writing multi-line output to GitHub Actions."""
         multi_line_value = "line1\nline2\nline3"
-        self.verifier.write_github_output("test_key", multi_line_value)
+        self.reporter.write_github_output("test_key", multi_line_value)
 
         with open(self.temp_output.name, "r") as f:
             content = f.read()
 
         assert "test_key<<EOF\nline1\nline2\nline3\nEOF\n" in content
 
-    @patch("http_api_tool.verifier.pycurl.Curl")
+    @patch("http_api_tool.curl_client.pycurl.Curl")
     def test_create_curl_handle_basic(self, mock_curl_class: Mock) -> None:
         """Test basic cURL handle creation."""
         mock_curl = Mock()
@@ -395,7 +397,7 @@ X-Custom-Header: test-value
             "include_response_body": True,
         }
 
-        _ = self.verifier.create_curl_handle(**config)
+        _ = create_curl_handle(self.reporter, **config)
 
         # Verify basic settings were applied
         mock_curl.setopt.assert_any_call(pycurl.URL, "https://example.com")
@@ -403,7 +405,7 @@ X-Custom-Header: test-value
         mock_curl.setopt.assert_any_call(pycurl.CUSTOMREQUEST, "GET")
         mock_curl.setopt.assert_any_call(pycurl.VERBOSE, False)
 
-    @patch("http_api_tool.verifier.pycurl.Curl")
+    @patch("http_api_tool.curl_client.pycurl.Curl")
     def test_create_curl_handle_ssl_disabled(self, mock_curl_class: Mock) -> None:
         """Test cURL handle creation with SSL verification disabled."""
         mock_curl = Mock()
@@ -420,13 +422,13 @@ X-Custom-Header: test-value
             "include_response_body": True,
         }
 
-        _ = self.verifier.create_curl_handle(**config)
+        _ = create_curl_handle(self.reporter, **config)
 
         # Verify SSL verification was disabled
         mock_curl.setopt.assert_any_call(pycurl.SSL_VERIFYPEER, 0)
         mock_curl.setopt.assert_any_call(pycurl.SSL_VERIFYHOST, 0)
 
-    @patch("http_api_tool.verifier.pycurl.Curl")
+    @patch("http_api_tool.curl_client.pycurl.Curl")
     def test_create_curl_handle_with_auth(self, mock_curl_class: Mock) -> None:
         """Test cURL handle creation with authentication."""
         mock_curl = Mock()
@@ -444,12 +446,12 @@ X-Custom-Header: test-value
             "include_response_body": True,
         }
 
-        _ = self.verifier.create_curl_handle(**config)
+        _ = create_curl_handle(self.reporter, **config)
 
         # Verify authentication was set
         mock_curl.setopt.assert_any_call(pycurl.USERPWD, "user:password")
 
-    @patch("http_api_tool.verifier.pycurl.Curl")
+    @patch("http_api_tool.curl_client.pycurl.Curl")
     def test_create_curl_handle_with_body(self, mock_curl_class: Mock) -> None:
         """Test cURL handle creation with request body."""
         mock_curl = Mock()
@@ -468,14 +470,14 @@ X-Custom-Header: test-value
             "include_response_body": True,
         }
 
-        _ = self.verifier.create_curl_handle(**config)
+        _ = create_curl_handle(self.reporter, **config)
 
         # Verify body was set
         expected_body = b'{"test": "data"}'
         mock_curl.setopt.assert_any_call(pycurl.POSTFIELDS, expected_body)
         mock_curl.setopt.assert_any_call(pycurl.POSTFIELDSIZE, len(expected_body))
 
-    @patch("http_api_tool.verifier.pycurl.Curl")
+    @patch("http_api_tool.curl_client.pycurl.Curl")
     def test_create_curl_handle_with_headers(self, mock_curl_class: Mock) -> None:
         """Test cURL handle creation with custom headers."""
         mock_curl = Mock()
@@ -493,7 +495,7 @@ X-Custom-Header: test-value
             "include_response_body": True,
         }
 
-        _ = self.verifier.create_curl_handle(**config)
+        _ = create_curl_handle(self.reporter, **config)
 
         # Check that headers were set (the exact call depends on the implementation)
         # We'll verify that setopt was called with HTTPHEADER
@@ -504,7 +506,7 @@ X-Custom-Header: test-value
         ]
         assert len(header_calls) > 0
 
-    @patch("http_api_tool.verifier.pycurl.Curl")
+    @patch("http_api_tool.curl_client.pycurl.Curl")
     def test_create_curl_handle_with_ca_bundle(self, mock_curl_class: Mock) -> None:
         """Test cURL handle creation with custom CA bundle."""
         mock_curl = Mock()
@@ -524,12 +526,12 @@ X-Custom-Header: test-value
 
         # Mock file existence check
         with patch("os.path.isfile", return_value=True):
-            _ = self.verifier.create_curl_handle(**config)
+            _ = create_curl_handle(self.reporter, **config)
 
         # Verify CA bundle was set
         mock_curl.setopt.assert_any_call(pycurl.CAINFO, "/path/to/ca-bundle.crt")
 
-    @patch("http_api_tool.verifier.pycurl.Curl")
+    @patch("http_api_tool.curl_client.pycurl.Curl")
     def test_create_curl_handle_with_invalid_ca_bundle(
         self, mock_curl_class: Mock
     ) -> None:
@@ -551,7 +553,7 @@ X-Custom-Header: test-value
 
         # Mock file existence check to return False
         with patch("os.path.isfile", return_value=False):
-            _ = self.verifier.create_curl_handle(**config)
+            _ = create_curl_handle(self.reporter, **config)
 
         # Verify CA bundle was NOT set when file doesn't exist
         ca_info_calls = [
@@ -578,7 +580,7 @@ X-Custom-Header: test-value
         }[info_type]
 
         # Mock response data
-        with patch("http_api_tool.verifier.BytesIO") as mock_bytesio:
+        with patch("http_api_tool.curl_client.BytesIO") as mock_bytesio:
             response_buffer = Mock()
             header_buffer = Mock()
             response_buffer.getvalue.return_value = b'{"status": "ok"}'
@@ -588,7 +590,7 @@ X-Custom-Header: test-value
 
             mock_bytesio.side_effect = [response_buffer, header_buffer]
 
-            result = self.verifier.perform_request(mock_curl)
+            result = perform_request(mock_curl)
 
             assert result["success"] is True
             assert result["http_code"] == 200
@@ -608,7 +610,7 @@ X-Custom-Header: test-value
         # Mock cURL error
         mock_curl.perform.side_effect = pycurl.error(7, "Failed to connect to host")
 
-        with patch("http_api_tool.verifier.BytesIO") as mock_bytesio:
+        with patch("http_api_tool.curl_client.BytesIO") as mock_bytesio:
             response_buffer = Mock()
             header_buffer = Mock()
             response_buffer.getvalue.return_value = b""
@@ -616,7 +618,7 @@ X-Custom-Header: test-value
 
             mock_bytesio.side_effect = [response_buffer, header_buffer]
 
-            result = self.verifier.perform_request(mock_curl)
+            result = perform_request(mock_curl)
 
             assert result["success"] is False
             assert result["http_code"] == 0
@@ -638,8 +640,8 @@ class TestIntegration:
         """Set up test fixtures."""
         self.verifier = HTTPAPITester()
 
-    @patch("http_api_tool.verifier.HTTPAPITester.create_curl_handle")
-    @patch("http_api_tool.verifier.HTTPAPITester.perform_request")
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
     def test_test_api_success_immediate(
         self, mock_perform: Mock, mock_create_handle: Mock
     ) -> None:
@@ -687,8 +689,8 @@ class TestIntegration:
         assert result["connect_time"] == 0.050
         assert result["time_delay"] == 0  # No delay on first attempt
 
-    @patch("http_api_tool.verifier.HTTPAPITester.create_curl_handle")
-    @patch("http_api_tool.verifier.HTTPAPITester.perform_request")
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
     @patch("time.sleep")  # Mock sleep to speed up test
     def test_test_api_success_with_retry(
         self, mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock
@@ -752,8 +754,8 @@ class TestIntegration:
         # Verify sleep was called
         mock_sleep.assert_called_once_with(1)
 
-    @patch("http_api_tool.verifier.HTTPAPITester.create_curl_handle")
-    @patch("http_api_tool.verifier.HTTPAPITester.perform_request")
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
     @patch("time.sleep")
     def test_test_api_with_regex_success(
         self, _mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock
@@ -801,8 +803,8 @@ class TestIntegration:
         assert result["response_http_code"] == 200
         assert result["regex_match"] is True
 
-    @patch("http_api_tool.verifier.HTTPAPITester.create_curl_handle")
-    @patch("http_api_tool.verifier.HTTPAPITester.perform_request")
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
     def test_test_api_response_time_exceeded(
         self, mock_perform: Mock, mock_create_handle: Mock
     ) -> None:
@@ -848,8 +850,8 @@ class TestIntegration:
         assert result["response_http_code"] == 200
         assert result["response_time_exceeded"] is True
 
-    @patch("http_api_tool.verifier.HTTPAPITester.create_curl_handle")
-    @patch("http_api_tool.verifier.HTTPAPITester.perform_request")
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
     @patch("time.sleep")
     def test_test_api_exhausted_retries(
         self, _mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock


### PR DESCRIPTION
## Summary

`aislop` scored this repository **38/100 (Critical)** with **47 findings**. This change takes it to **100/100 (Healthy)** with **zero findings**, by fixing the causes rather than suppressing the rules — no `.aislop` config, no ignore file, no inline suppressions.

### Findings addressed

| Rule | Count | Remediation |
| --- | --- | --- |
| `ai-slop/python-print-debug` | 26 | Operator output now goes through `typer.echo` instead of `print`, so the package writes to one console layer instead of two |
| `ai-slop/trivial-comment` | 16 | Removed comments that restated the following line |
| `ai-slop/narrative-comment` | 1 | Rewrote a cross-reference comment to state the reason instead |
| `complexity/file-too-large` | 1 | `verifier.py` split from 794 lines into five focused modules |
| `complexity/function-too-long` | 1 | `test_api` reduced from 202 lines to a flat loop over named helpers |
| `complexity/deep-nesting` | 1 | `test_api` nesting reduced from depth 7 to depth 3 |
| `python-formatting` | 1 | Formatted `scripts/check-pip-security.py` |

### Module split

`HTTPAPITester` had grown into a god object mixing redaction, validation, transport, and retry orchestration. It is now split along its existing seams:

- **`sanitize.py`** — redaction helpers and URL parsing as pure functions. `cli.py` no longer constructs a throwaway `HTTPAPITester` just to reach them.
- **`reporting.py`** — `ActionReporter` owns every output channel: stdout, `GITHUB_STEP_SUMMARY`, `GITHUB_OUTPUT`, and the `::add-mask::` workflow commands.
- **`validation.py`** — normalises the untyped strings GitHub Actions supplies.
- **`curl_client.py`** — pycurl handle construction and request execution.
- **`verifier.py`** — `HTTPAPITester` remains the retry orchestrator, now 271 lines.

### Incidental fixes

- The ruff `pre-commit` patterns only covered `^(src|tests)/`, which is why `scripts/check-pip-security.py` had drifted out of format. Widened to `^(src|tests|scripts)/` so it cannot drift again.
- `handle_curl_error` dropped its unused `_error_msg` parameter.
- The response-code hints for exhausted retries are now a lookup table rather than an `if`/`elif` ladder.

## Behaviour

Unchanged. The public entry points (`http-api-tool` console script, `python -m http_api_tool`, `HTTPAPITester`) keep their contracts. `HTTPAPITester` now accepts an optional `ActionReporter`, defaulting to a fresh one.

## Validation

- `pytest` — 47 passed (unchanged count; tests updated for the new module locations).
- `prek run --all-files` — all hooks pass (ruff, ruff-format, mypy, basedpyright, interrogate at 98.3%, reuse, codespell, yamllint, actionlint).
- `aislop scan` — 100/100, 0 findings across all five engines. `aislop ci` exits 0.
- Manual end-to-end runs against a local HTTP server covering: CLI success with regex and `--debug`; GitHub Actions mode with embedded URL credentials (verified `::add-mask::` emission, URL sanitisation, `Authorization` header redaction, base64 body, `GITHUB_OUTPUT`, step summary); 404 retry exhaustion with the hint path; connection-refused retry and exit; missing-URL validation error; `--version`.
