### PR TITLE
Fix: Correct compounding retry backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docker run --rm --entrypoint=/usr/local/bin/uv \
 - **Supported HTTP Methods**: Supports GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
 - **Authentication**: Basic Auth via auth_string and custom headers support
 - **Response Validation**: Status code, regex pattern matching, response time limits
-- **Retry Logic**: Configurable exponential backoff with jitter
+- **Retry Logic**: Exponential backoff, doubling up to a configurable cap
 - **Dual Usage**: Works as both a CLI tool and GitHub Action
 - **Robust Error Handling**: Detailed error messages and proper exit codes
 - **JSON Safety**: Uses pycurl instead of shell commands to avoid escaping issues
@@ -218,7 +218,7 @@ uv run python -m http_api_tool test \
 | `url`                   | URL of API server/interface to check                                 | Yes      | -                  |
 | `auth_string`           | Authentication string, colon separated username/password             | No       | -                  |
 | `service_name`          | Name of HTTP/HTTPS API service tested                                | No       | `API Service`      |
-| `initial_sleep_time`    | Time in seconds between API service connection attempts              | No       | `1`                |
+| `initial_sleep_time`    | Delay in seconds before the first retry, doubling thereafter         | No       | `1`                |
 | `max_delay`             | Max delay in seconds between retries                                 | No       | `30`               |
 | `retries`               | Number of retries before declaring service unavailable               | No       | `3`                |
 | `expected_http_code`    | HTTP response code to accept from the API service                    | No       | `200`              |

--- a/action.yaml
+++ b/action.yaml
@@ -39,9 +39,9 @@ inputs:
     required: false
     default: 'API Service'
   initial_sleep_time:
-    description: 'Time in seconds between API service connection attempts'
+    description: 'Delay in seconds before the first retry, doubling thereafter'
     required: false
-    # Try once every second
+    # Wait a second before the first retry
     default: '1'
   max_delay:
     description: 'Maximum delay in seconds between retries'

--- a/src/http_api_tool/cli.py
+++ b/src/http_api_tool/cli.py
@@ -113,7 +113,7 @@ def verify(
         "API Service", help="Name of HTTP/HTTPS API service tested"
     ),
     initial_sleep_time: int = typer.Option(
-        1, help="Time in seconds between API service connection attempts"
+        1, help="Delay in seconds before the first retry, doubling thereafter"
     ),
     max_delay: int = typer.Option(30, help="Maximum delay in seconds between retries"),
     retries: int = typer.Option(

--- a/src/http_api_tool/verifier.py
+++ b/src/http_api_tool/verifier.py
@@ -235,7 +235,7 @@ class HTTPAPITester:
         result = _initial_result()
         counter = 0
         time_delay = 0
-        sleep_time = config["initial_sleep_time"]
+        sleep_time = min(config["initial_sleep_time"], config["max_delay"])
 
         while True:
             counter += 1
@@ -267,5 +267,5 @@ class HTTPAPITester:
             self.reporter.log(f"Waiting for {sleep_time} seconds before retrying...")
             time.sleep(sleep_time)
             time_delay += sleep_time
-            sleep_time = min(sleep_time * (2 ** (counter - 1)), config["max_delay"])
+            sleep_time = min(sleep_time * 2, config["max_delay"])
             self.reporter.log(f"Sleep/wait time for next attempt: {sleep_time} seconds")

--- a/tests/test_http_api_tool.py
+++ b/tests/test_http_api_tool.py
@@ -625,6 +625,50 @@ X-Custom-Header: test-value
             assert result["curl_error"] == (7, "Failed to connect to host")
 
 
+def failed_response() -> dict[str, Any]:
+    """Build a perform_request result representing a connection failure."""
+    return {
+        "success": False,
+        "http_code": 0,
+        "total_time": 0,
+        "connect_time": 0,
+        "body_size": 0,
+        "header_size": 0,
+        "response_body": b"",
+        "response_headers": "",
+        "header_json": "{}",
+        "curl_error": (7, "Failed to connect"),
+    }
+
+
+def retry_config(**overrides: Any) -> dict[str, Any]:
+    """Build a test_api config, applying any per-test overrides."""
+    config: dict[str, Any] = {
+        "url": "https://example.com",
+        "service_name": "Test API",
+        "retries": 2,
+        "expected_http_code": 200,
+        "initial_sleep_time": 1,
+        "max_delay": 30,
+        "curl_timeout": 5,
+        "http_method": "GET",
+        "verify_ssl": True,
+        "connection_reuse": True,
+        "follow_redirects": True,
+        "debug": False,
+        "include_response_body": False,
+        "max_response_time": 0,
+        "fail_on_timeout": False,
+    }
+    config.update(overrides)
+    return config
+
+
+def recorded_sleeps(mock_sleep: Mock) -> list[float]:
+    """Extract the interval passed to each time.sleep call, in order."""
+    return [call.args[0] for call in mock_sleep.call_args_list]
+
+
 @pytest.mark.integration
 class TestIntegration:
     """Integration tests for the complete verification flow.
@@ -857,44 +901,82 @@ class TestIntegration:
         self, _mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock
     ) -> None:
         """Test API verification with exhausted retries."""
-        # Mock curl handle
-        mock_curl = Mock()
-        mock_create_handle.return_value = mock_curl
-
-        # Mock consistent failures
-        mock_perform.return_value = {
-            "success": False,
-            "http_code": 0,
-            "total_time": 0,
-            "connect_time": 0,
-            "body_size": 0,
-            "header_size": 0,
-            "response_body": b"",
-            "response_headers": "",
-            "header_json": "{}",
-            "curl_error": (7, "Failed to connect"),
-        }
-
-        config = {
-            "url": "https://example.com",
-            "service_name": "Test API",
-            "retries": 2,
-            "expected_http_code": 200,
-            "initial_sleep_time": 1,
-            "max_delay": 30,
-            "curl_timeout": 5,
-            "http_method": "GET",
-            "verify_ssl": True,
-            "connection_reuse": True,
-            "follow_redirects": True,
-            "debug": False,
-            "include_response_body": False,
-            "max_response_time": 0,
-            "fail_on_timeout": False,
-        }
+        mock_create_handle.return_value = Mock()
+        mock_perform.return_value = failed_response()
 
         with pytest.raises(SystemExit):
+            _ = self.verifier.test_api(**retry_config(retries=2))
+
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
+    @patch("time.sleep")
+    def test_test_api_backoff_doubles_each_attempt(
+        self, mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock
+    ) -> None:
+        """Test that the retry interval doubles between attempts."""
+        mock_create_handle.return_value = Mock()
+        mock_perform.return_value = failed_response()
+
+        config = retry_config(retries=5, initial_sleep_time=1, max_delay=30)
+        with pytest.raises(SystemExit):
             _ = self.verifier.test_api(**config)
+
+        # Five attempts means four waits, each twice the one before it.
+        assert recorded_sleeps(mock_sleep) == [1, 2, 4, 8]
+
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
+    @patch("time.sleep")
+    def test_test_api_backoff_stops_at_max_delay(
+        self, mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock
+    ) -> None:
+        """Test that the retry interval never exceeds max_delay."""
+        mock_create_handle.return_value = Mock()
+        mock_perform.return_value = failed_response()
+
+        config = retry_config(retries=4, initial_sleep_time=10, max_delay=15)
+        with pytest.raises(SystemExit):
+            _ = self.verifier.test_api(**config)
+
+        assert recorded_sleeps(mock_sleep) == [10, 15, 15]
+
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
+    @patch("time.sleep")
+    def test_test_api_backoff_caps_the_first_wait(
+        self, mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock
+    ) -> None:
+        """Test that max_delay caps initial_sleep_time as well."""
+        mock_create_handle.return_value = Mock()
+        mock_perform.return_value = failed_response()
+
+        config = retry_config(retries=3, initial_sleep_time=60, max_delay=30)
+        with pytest.raises(SystemExit):
+            _ = self.verifier.test_api(**config)
+
+        assert recorded_sleeps(mock_sleep) == [30, 30]
+
+    @patch("http_api_tool.verifier.create_curl_handle")
+    @patch("http_api_tool.verifier.perform_request")
+    @patch("time.sleep")
+    def test_test_api_reports_total_delay_on_failure(
+        self, _mock_sleep: Mock, mock_perform: Mock, mock_create_handle: Mock
+    ) -> None:
+        """Test that time_delay accumulates every backoff interval."""
+        mock_create_handle.return_value = Mock()
+        mock_perform.return_value = failed_response()
+        recorded: dict[str, Any] = {}
+
+        def capture(result: dict[str, Any], *_args: Any) -> None:
+            recorded.update(result)
+
+        config = retry_config(retries=4, initial_sleep_time=1, max_delay=30)
+        with patch.object(HTTPAPITester, "_report_exhausted", side_effect=capture):
+            with pytest.raises(SystemExit):
+                _ = self.verifier.test_api(**config)
+
+        # Waits of 1, 2, and 4 seconds precede the fourth and final attempt.
+        assert recorded["time_delay"] == 7
 
     # NOTE: Response time testing is now covered by the testing.yaml workflow
     # using a local go-httpbin service to avoid external dependencies in unit tests.


### PR DESCRIPTION
Follows up on [this review comment](https://github.com/lfreleng-actions/http-api-tool-docker/pull/353#discussion_r3783167892), which was deliberately left unfixed in #353 to keep that PR behaviour-neutral. #353 has since merged, and this branch is now rebased onto current `main` as a single commit.

## The bug

```python
sleep_time = min(sleep_time * (2 ** (counter - 1)), config["max_delay"])
```

`sleep_time` is reassigned each iteration *and* the exponent grows with the attempt number, so the multiplier compounds against an already-multiplied interval. With the defaults (`initial_sleep_time: 1`, `max_delay: 30`) the actual waits were:

| Retry | Before | After |
| --- | --- | --- |
| 1 | 1s | 1s |
| 2 | 1s | 2s |
| 3 | 2s | 4s |
| 4 | 8s | 8s |
| 5 | 30s (capped) | 16s |
| 6 | 30s | 30s (capped) |

Two visible symptoms: the first interval repeats, and the gap between attempts 3 and 4 jumps 4× rather than 2×, so the `max_delay` ceiling arrives an attempt or two early.

## The fix

```python
sleep_time = min(sleep_time * 2, config["max_delay"])
```

The interval now doubles from `initial_sleep_time` until it reaches `max_delay`.

`max_delay` also bounds the opening wait now (raised in review):

```python
sleep_time = min(config["initial_sleep_time"], config["max_delay"])
```

It is documented as "Maximum delay in seconds between retries" with no carve-out, but `initial_sleep_time` previously reached `time.sleep()` unclamped, so `initial_sleep_time: 60` with `max_delay: 30` produced waits of `60, 30, 30`. Only reachable with a self-contradictory configuration.

## Tests

The wait schedule had no coverage at all, which is how this survived. Four integration tests now pin it down:

- `test_test_api_backoff_doubles_each_attempt` — asserts the schedule is `[1, 2, 4, 8]`
- `test_test_api_backoff_stops_at_max_delay` — asserts `[10, 15, 15]` for `initial_sleep_time: 10`, `max_delay: 15`
- `test_test_api_backoff_caps_the_first_wait` — asserts `[30, 30]` for `initial_sleep_time: 60`, `max_delay: 30`
- `test_test_api_reports_total_delay_on_failure` — asserts the `time_delay` output totals every wait

Each fails against the previous implementation (verified by reverting each fix in turn) and passes against this one. The existing `test_test_api_exhausted_retries` moved onto the same shared `failed_response()` / `retry_config()` helpers rather than repeating the response and config dictionaries a fifth time.

## Documentation

The README advertised **"exponential backoff with jitter"** — there is no jitter anywhere in the codebase, and never has been (the claim dates to the initial commit), and the backoff was not exponential either. `initial_sleep_time` was described as "Time in seconds between API service connection attempts" in the README table, the action input, and the CLI `--help`, which reads as a fixed interval rather than the starting point of a backoff. All four corrected.

## Compatibility

This changes retry timing, which is why it was not folded into #353. Consumers who tuned `retries` against the old schedule will see a service marked failed at a different elapsed time, and the `time_delay` output changes for runs reaching three or more attempts. Total wait to exhaustion is now shorter for mid-range retry counts and longer beyond the cap. No inputs or outputs change shape.

## Validation

Re-run after rebasing onto `main` (which brought a pre-commit autoupdate: ruff v0.16.3, mypy v2.3.1, basedpyright 1.39.10):

- `pytest` — 51 passed
- `prek run --all-files` — all hooks pass against the updated hook versions
- `zizmor --persona auditor action.yaml` — no findings
- `aislop scan` — code-quality, ai-slop, formatting and linting engines all report 0 issues

> [!NOTE]
> `aislop` currently reports 6 `security/vulnerable-dependency` errors (`idna`, `msgpack`, `pip`, `pygments`, `requests`, `urllib3`). These are **pre-existing on `main`** and unrelated to this change — a pristine `main` worktree scores identically. Worth tracking separately.
