### PR TITLE
CI: Bump pypi-publish-action to v0.2.0

### DIFF
--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -351,7 +351,7 @@ jobs:
 
       - name: 'Test PyPI publishing'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: 'development'
           tag: "${{ needs.tag-validate.outputs.tag }}"
@@ -463,7 +463,7 @@ jobs:
 
       - name: 'PyPI release'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/pypi-publish-action@8e46bf1bb34889591549c37d949d38fee1ab2d6b  # v0.1.9
+        uses: lfreleng-actions/pypi-publish-action@276603f5d72b11427755ef139c6fb80489cec5d9  # v0.2.0
         with:
           environment: 'production'
           attestations: true


### PR DESCRIPTION
## Problem

The `Test PyPI Publishing` job fails, which skips the PyPI release:

```
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a
      valid metadata version
```

Seen in [run 32022654932](https://github.com/lfreleng-actions/http-api-tool-docker/actions/runs/32022654932).

## Cause

Current build backends emit `Metadata-Version: 2.5`. The publish backend
bundled with `pypi-publish-action` v0.1.9 (`gh-action-pypi-publish` v1.11.8)
carries twine 6.2.0, whose `packaging` predates that metadata version and
rejects the distribution before upload.

## Fix

Bump to `pypi-publish-action` v0.2.0, which moves the backend to
`gh-action-pypi-publish` v1.11.11 — twine 7.0.0 and packaging 26.3.

Verified locally: twine 7.0.0 accepts a hatchling-built sdist and wheel that
twine 6.2.0 rejects with exactly this error.

Dependabot would propose the same bump, but its `github-actions` cooldown
holds it until Friday, leaving releases broken until then.

## Follow-up

Tag-push workflows read their definition from the tag's commit, so re-running
the failed job will still use v0.1.9. Once this merges, a fresh tag is needed
to publish.